### PR TITLE
alter insights again

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -8,7 +8,7 @@
       "bureau-smartSurveyToken": "",
       "bureau-smartSurveyTokenSecret": "",
       "launchDarklyKey": "",
-      "app-insights-connection-string": "app-insights-connection-string"
+      "app-insights-connection-string": ""
     }
   }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -8,7 +8,7 @@
       "bureau-smartSurveyToken": "",
       "bureau-smartSurveyTokenSecret": "",
       "launchDarklyKey": "",
-      "app-insights-connection-string": "app-insights-connection-string"
+      "app-insights-connection-string": ""
     }
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -8,7 +8,7 @@
       "bureau-smartSurveyToken": "",
       "bureau-smartSurveyTokenSecret": "",
       "launchDarklyKey": "",
-      "app-insights-connection-string": "app-insights-connection-string"
+      "app-insights-connection-string": ""
     }
   }
 }

--- a/server/lib/appinsights.js
+++ b/server/lib/appinsights.js
@@ -4,7 +4,9 @@ const secretsConfig = require('config');
 module.exports.AppInsights = class AppInsights {
 
   constructor() {
-    if (secretsConfig.get('secrets.juror.app-insights-connection-string')) {
+    const appInsightsString = secretsConfig.get('secrets.juror.app-insights-connection-string')
+
+    if (appInsightsString) {
       console.log('Starting Appinsights');
 
       appInsights.setup(secretsConfig.get('secrets.juror.app-insights-connection-string'))

--- a/server/lib/appinsights.js
+++ b/server/lib/appinsights.js
@@ -9,7 +9,7 @@ module.exports.AppInsights = class AppInsights {
     if (appInsightsString) {
       console.log('Starting Appinsights');
 
-      appInsights.setup(secretsConfig.get('secrets.juror.app-insights-connection-string'))
+      appInsights.setup(appInsightsString)
         .setAutoCollectConsole(true, true)
         .setSendLiveMetrics(true)
         .start();


### PR DESCRIPTION
Default app-insights-connection-string to "" in json files to allow test for empty string to be used in lib/appinsights.js

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
