### PR TITLE
Feature (JM-6611) pull juror name from validate movement API for errors

### DIFF
--- a/server/config/validation/juror-bulk-transfer.js
+++ b/server/config/validation/juror-bulk-transfer.js
@@ -51,43 +51,6 @@
       }];
     };
 
-    const results = attributes.selectedJurors.reduce((prev, curr, index) => {
-      const date = attributes.jurorDates[index];
-
-      const oldAttendanceDate = moment();
-
-      oldAttendanceDate.date(date[2]);
-      oldAttendanceDate.month(date[1] - 1);
-      oldAttendanceDate.year(date[0]);
-
-      if (
-        modUtils.dateDifference(
-          dateInitial.dateAsDate,
-          oldAttendanceDate,
-          'days'
-        ) < 0
-      ) {
-        prev.push([curr, oldAttendanceDate]);
-
-        return prev;
-      }
-
-      return prev;
-    }, []);
-
-    if (results.length > 0) {
-      const message = {
-        summary: 'You cannot enter a date that’s earlier than the original service start date' 
-      };
-
-      results.forEach(([juror, date]) => {
-        tmpErrors.push({
-          ...message,
-          details: 'You cannot enter a date that’s earlier than the original service start date'
-        });
-      });
-    }
-
     return tmpErrors.length === 0
       ? null
       : tmpErrors;

--- a/server/config/validation/juror-bulk-transfer.spec.js
+++ b/server/config/validation/juror-bulk-transfer.spec.js
@@ -1,19 +1,19 @@
 /* eslint-disable */
 (function() {
     'use strict';
-  
+
     var validate = require('validate.js')
       , transferValidator = require('./juror-bulk-transfer')
       , validatorResult = null
       , moment = require('moment');
-  
-    // TODO Not yet implemented
+
+      // TODO Not yet implemented
     describe('Juror bulk transfer validators:', function() {
-  
+
       beforeEach(function() {
         validatorResult = null;
       });
-  
+
       it('should validate a valid request', function() {
         var mockRequest = {
           courtNameOrLocation: 'Liverpool (433)',
@@ -21,12 +21,12 @@
           selectedJurors: ['415230701'], 
           jurorDates: [[ 2023, 5, 30 ]]
         };
-  
+
         validatorResult = validate(mockRequest, transferValidator());
 
         expect(validatorResult).to.be.undefined;
       });
-  
+
       it('should validate a valid request with mutiple entries', function() {
         var mockRequest = {
           courtNameOrLocation: 'Liverpool (433)',
@@ -34,12 +34,12 @@
           selectedJurors: ['415230701', '415230702'], 
           jurorDates: [[ 2023, 5, 30 ], [ 2023, 5, 28 ]]
         };
-  
+
         validatorResult = validate(mockRequest, transferValidator());
 
         expect(validatorResult).to.be.undefined;
       });
-  
+
       it('should try to validate an invalid request - missing all fields', function() {
         var mockRequest = {
           courtNameOrLocation: '',
@@ -57,7 +57,6 @@
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date DAY', function() {
@@ -69,11 +68,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date MONTH', function() {
@@ -85,11 +83,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date YEAR', function() {
@@ -101,11 +98,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date DAY and MONTH', function() {
@@ -117,11 +113,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date DAY and YEAR', function() {
@@ -133,11 +128,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - missing new start date DAY and YEAR', function() {
@@ -149,11 +143,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a transfer date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - invalid DAY input ', function() {
@@ -165,11 +158,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - invalid MONTH input ', function() {
@@ -181,11 +173,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - invalid YEAR input ', function() {
@@ -201,7 +192,6 @@
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Year must have 4 numbers');
-
       });
 
       it('should try to validate an invalid request - impossible date (> 29/02) ', function() {
@@ -213,11 +203,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Enter a date in the correct format, for example, 31/01/2023');
-
       });
 
       it('should try to validate an invalid request - new date is more than 12 months in the future ', function() {
@@ -229,65 +218,10 @@
         };
 
         validatorResult = validate(mockRequest, transferValidator());
-  
+
         expect(validatorResult).to.be.an('object');
         expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
         expect(validatorResult.jurorTransferDate[0].summary).to.equal('Service start date must be within the next 12 months');
-
       });
-
-      it('should try to validate an invalid request - new date is earlier than the original date', function() {
-        var mockRequest = {
-          courtNameOrLocation: 'Liverpool (433)',
-          attendanceDate: '12/12/2022',
-          selectedJurors: ['415230701'], 
-          jurorDates: [[ 2023, 5, 30 ]]
-        };
-
-        validatorResult = validate(mockRequest, transferValidator());
-
-        expect(validatorResult).to.be.an('object');
-        expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
-        expect(validatorResult.jurorTransferDate[0].summary).to.equal('You cannot enter a date that’s earlier than the original service start date');
-
-      });
-  
-      it('should try to validate an invalid request - new date is earlier than the original date for only one bulk juror', function() {
-        var mockRequest = {
-          courtNameOrLocation: 'Liverpool (433)',
-          attendanceDate: '12/12/2022',
-          selectedJurors: ['415230701', '415230702'], 
-          jurorDates: [[ 2023, 5, 30 ], [ 2022, 10, 19 ]]
-        };
-
-        validatorResult = validate(mockRequest, transferValidator());
-
-        expect(validatorResult).to.be.an('object');
-        expect(validatorResult.jurorTransferDate).to.have.length(1);
-        expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
-        expect(validatorResult.jurorTransferDate[0].summary).to.equal('You cannot enter a date that’s earlier than the original service start date');
-
-      });
-
-      it('should try to validate an invalid request - new date is earlier than the original date for multiple bulk juror', function() {
-        var mockRequest = {
-          courtNameOrLocation: 'Liverpool (433)',
-          attendanceDate: '12/12/2022',
-          selectedJurors: ['415230701', '415230702'], 
-          jurorDates: [[ 2023, 5, 30 ], [2023, 5, 28 ]]
-        };
-
-        validatorResult = validate(mockRequest, transferValidator());
-
-        expect(validatorResult).to.be.an('object');
-        expect(validatorResult.jurorTransferDate).to.have.length(2);
-        expect(validatorResult.jurorTransferDate[0]).to.have.ownPropertyDescriptor('summary');
-        expect(validatorResult.jurorTransferDate[0].summary).to.equal('You cannot enter a date that’s earlier than the original service start date');
-        expect(validatorResult.jurorTransferDate[1].summary).to.equal('You cannot enter a date that’s earlier than the original service start date');
-
-      });
-  
     });
-  
   })();
-  

--- a/server/lib/mod-utils.js
+++ b/server/lib/mod-utils.js
@@ -1058,14 +1058,14 @@
     return `${hour}:${minute}`;
   };
 
-  module.exports.buildMovementProblems = function(data, sessionDetails) {
+  module.exports.buildMovementProblems = function(data) {
     if (data.unavailableForMove.length){
       let unavailableReasons = {ageIneligible: [], invalidStatus: [], noActiveRecord: []};
       const reasons = data.unavailableForMove.reduce((accumulator, currentValue) => {
         let jurorDetails = {
           jurorNumber: currentValue.jurorNumber,
-          firstName: sessionDetails[currentValue.jurorNumber].firstName,
-          lastName: sessionDetails[currentValue.jurorNumber].lastname,
+          firstName: currentValue.firstName || currentValue['first_name'],
+          lastName: currentValue.lastname || currentValue['last_name'],
         };
 
         if (currentValue.failureReason.includes('maximum age')){

--- a/server/routes/juror-management/postpone/postpone.controller.js
+++ b/server/routes/juror-management/postpone/postpone.controller.js
@@ -310,7 +310,7 @@ const { flowLetterGet, flowLetterPost } = require('../../../lib/flowLetter');
           req.session.jurorCommonDetails.payload.juror_numbers.length,
         continueUrl: app.namedRoutes.build('juror.update-bulk-postpone.continue.post', {
           poolNumber: req.params['poolNumber']}),
-        problems: modUtils.buildMovementProblems(req.session.movementData, req.session.jurorDetails),
+        problems: modUtils.buildMovementProblems(req.session.movementData),
       });
     };
   };

--- a/server/routes/juror-management/reassign/reassign.controller.js
+++ b/server/routes/juror-management/reassign/reassign.controller.js
@@ -294,7 +294,7 @@
             return res.render('pool-management/movement/bulk-validate', {
               cancelUrl: cancelUrl,
               continueUrl: continueUrl,
-              problems: modUtils.buildMovementProblems(data, req.session.jurorDetails),
+              problems: modUtils.buildMovementProblems(data),
             });
           }
 

--- a/server/routes/juror-management/update/juror-update.transfer.controller.js
+++ b/server/routes/juror-management/update/juror-update.transfer.controller.js
@@ -145,7 +145,6 @@
           poolNumber: req.params.poolNumber,
         });
         req.body.selectedJurors = req.session.poolJurorsTransfer.selectedJurors;
-        req.body.jurorDates = req.body.selectedJurors.map(id => req.session.jurorDetails[id].startDate);
         validatorResult = validate(req.body, jurorBulkTransferValidator());
         movementValidateRoute = 'pool-management/movement/bulk-validate.njk';
       }
@@ -180,13 +179,14 @@
             jurorNumbers: req.body.selectedJurors,
           })
             .then((data) => {
-              if (data.unavailableForTransfer != null) {
-                req.session.availableForTransfer = data.availableForTransfer;
+              console.log(data);
+              if (data.unavailableForMove != null) {
+                req.session.availableForMove = data.availableForMove;
 
                 return res.render(movementValidateRoute, {
                   cancelUrl: failUrl,
                   continueUrl: continueUrl,
-                  problems: modUtils.buildMovementProblems(data, req.session.jurorDetails),
+                  problems: modUtils.buildMovementProblems(data),
                 });
               }
 

--- a/server/routes/juror-management/update/juror-update.transfer.controller.js
+++ b/server/routes/juror-management/update/juror-update.transfer.controller.js
@@ -179,7 +179,6 @@
             jurorNumbers: req.body.selectedJurors,
           })
             .then((data) => {
-              console.log(data);
               if (data.unavailableForMove != null) {
                 req.session.availableForMove = data.availableForMove;
 

--- a/server/routes/pool-management/pool-overview/pool-overview.controller.js
+++ b/server/routes/pool-management/pool-overview/pool-overview.controller.js
@@ -266,7 +266,7 @@ const filters = require('../../../components/filters');
 
   module.exports.postTransferContinue = function(app) {
     return (req, res) => {
-      executeTransfer(app, req, res, req.session.availableForTransfer);
+      executeTransfer(app, req, res, req.session.availableForMove);
     };
   };
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6611

### Change description ###

With the new pool overview, we don't necessarily have juror details for FE validation, or for error messaging when something goes wrong. This change removes FE validation relying on juror data we might not have, and makes it so that we pull the juror name is pulled from the validation API.

This requires https://github.com/hmcts/juror-api/pull/93 to work, but will be no worse because it currently crashes for lack of data where it's currently looking.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
