### PR TITLE
hotfix/JM-5746 - Cannot edit juror details from juror record while a summons reply is active 

### DIFF
--- a/client/templates/juror-management/juror-record/details.njk
+++ b/client/templates/juror-management/juror-record/details.njk
@@ -35,17 +35,15 @@
     {% set emailAddress = "<span class=\"mod-contact-third-party\">Contact Third Party</span>" %}
   {% endif %}
 
-  {% if juror.replyProcessingStatus !== 'To Do' %}
-    {% set editDetailsLink %}
-      {{ url('juror-record.details-edit.get', { jurorNumber: juror.commonDetails.jurorNumber }) }}
-    {% endset %}
-  {% endif %}
+  {% set editDetailsLink %}
+    {{ url('juror-record.details-edit.get', { jurorNumber: juror.commonDetails.jurorNumber }) }}
+  {% endset %}
 
   {% include "../_partials/heading.njk" %}
 
   <div class="mod-juror-record__title govuk-body">
     <h2 id="jurorDetailsLabel" class="govuk-heading-m">Juror details</h2>
-    {% if (authentication.owner === juror.commonDetails.owner) and (editDetailsLink) %}
+    {% if authentication.owner === juror.commonDetails.owner %}
       <a id="changeJurorDetailsAnchor" href="{{ editDetailsLink }}" class="govuk-link">Add or change</a>
     {% endif %}
   </div>


### PR DESCRIPTION
### JIRA link ###

[JM-5746](https://centralgovernmentcgi.atlassian.net/browse/JM-5746)

### Description ###

Allow the edit of a juror's details from their Juror Record even if a summons reply has been received and processed.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
