### PR TITLE
JM-6823:  'generate panel' button should not be visible

### DIFF
--- a/client/templates/trial-management/trial-detail.njk
+++ b/client/templates/trial-management/trial-detail.njk
@@ -128,15 +128,14 @@
               href: url('trial-management.empanel.get', {trialNumber: trial.trial_number, locationCode: locationCode})
             }) if not trial.is_jury_empanelled }}
           
-          
-
           {% else %}
-            {{ govukButton({
-              text: "Generate panel",
-              classes: "govuk-button--secondary",
-              href: url('trial-management.generate-panel.get', {trialNumber: trial.trial_number, locationCode: locationCode})
-            }) }}
-
+            {% if addPanelStatus === false %}
+              {{ govukButton({
+                text: "Generate panel",
+                classes: "govuk-button--secondary",
+                href: url('trial-management.generate-panel.get', {trialNumber: trial.trial_number, locationCode: locationCode})
+              }) }}
+            {% endif %}
             {{ govukButton({
               text: "Edit trial",
               classes: "govuk-button--secondary",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6823

### Change description ###
‘Generate panel’ button should not be visible, only ‘Add panel members’


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
