### PR TITLE
add logging to stdout back into production

### DIFF
--- a/server/config/environment/production.js
+++ b/server/config/environment/production.js
@@ -5,7 +5,7 @@
   // =================================
   module.exports = {
     // If true, logs will be output in terminal as well as saved to file
-    logConsole: false,
+    logConsole: 'debug',
 
     // Response editing,  default=false
     responseEditEnabled: false,


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Production should read logs from stdout as opposed to just transport them to the api like before.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
