### PR TITLE
Bug (JM-6814) fix crash on empty bulk next due at court

### DIFF
--- a/server/config/validation/change-attendance-date.js
+++ b/server/config/validation/change-attendance-date.js
@@ -92,7 +92,7 @@
       details: [],
     };
 
-    if (attributes.selectedJurors.length === 0) {
+    if (!attributes.selectedJurors || attributes.selectedJurors.length === 0) {
       message.summary =
         'You need to select at least one juror before you can change the date they’re next due at court';
       message.details.push('Select at least one juror');


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6814

### Change description ###

Fix validation crash if selectedJurors is null on bulk update next due date

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
