### PR TITLE
hotfix/JM-6799&6937: Validation for adding attendance/non-attendance dates in future

### DIFF
--- a/client/templates/juror-management/attendance/add-attendance.njk
+++ b/client/templates/juror-management/attendance/add-attendance.njk
@@ -44,7 +44,7 @@
             text: "Enter attendance date"
           },
           hint: "Use dd/mm/yyyy format. For example, 31/01/2024.",
-          dateMin: "" | makeDate | dateFilter(null, "DD/MM/YYYY"),
+          dateMax: "" | makeDate | dateFilter(null, "DD/MM/YYYY"),
           dateValue: tmpFields.attendanceDay,
           dateError: attendanceDayError
         }) }}

--- a/client/templates/juror-management/non-attendance-day.njk
+++ b/client/templates/juror-management/non-attendance-day.njk
@@ -36,7 +36,8 @@
           id: "nonAttendanceDay",
           hint: "Use dd/mm/yyyy format. For example, 31/01/2023.",
           dateValue: tmpFields.nonAttendanceDay,
-          dateError: nonAttendanceDayError
+          dateError: nonAttendanceDayError, 
+          dateMax: "" | makeDate | dateFilter(null, "DD/MM/YYYY")
         }) }}
         <div class="govuk-button-group">
             {{ govukButton({

--- a/server/config/validation/add-attendance.js
+++ b/server/config/validation/add-attendance.js
@@ -55,6 +55,11 @@
           summary: 'Please enter a valid date for the attendance day',
           details: 'Please enter a valid date for the attendance day',
         }];
+      } else if (moment(dateInitial.dateAsDate).isAfter(new Date())) {
+        tmpErrors = [{
+          summary: 'Attendance day cannot be in the future',
+          details: 'Attendance day cannot be in the future',
+        }];
       }
     }
 

--- a/server/config/validation/non-attendance-day.js
+++ b/server/config/validation/non-attendance-day.js
@@ -43,6 +43,11 @@
           summary: 'Please enter a valid date for the non-attendance day',
           details: 'Please enter a valid date for the non-attendance day',
         }];
+      } else if (moment(dateInitial.dateAsDate).isAfter(new Date())) {
+        tmpErrors = [{
+          summary: 'Non-attendance day cannot be in the future',
+          details: 'Non-attendance day cannot be in the future',
+        }];
       }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6799
https://centralgovernmentcgi.atlassian.net/browse/JM-6799

### Change description ###

Added validation to ensure that attendance/non-attendance dates cannot be added for the future in FE.
FIxed small date picker issue not allowing past dates selection

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
