### PR TITLE
hotfix/JM-6671: Removed 'check can accommodate button' if response status is closed

### DIFF
--- a/client/templates/response/_partials/reasonable-adjustments.njk
+++ b/client/templates/response/_partials/reasonable-adjustments.njk
@@ -89,7 +89,7 @@
       </tbody>
     </table>
 
-    {% if hasModAccess and response.specialNeeds.length > 0 and not opticReference %}
+    {% if hasModAccess and response.specialNeeds.length > 0 and not opticReference and response.processingStatus !== 'Closed'%}
       {{ govukButton({
         text: "Check court can accommodate",
         classes: "govuk-button--secondary",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6671

### Change description ###

Removed 'check can accommodate button' if response status is closed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
