### PR TITLE
Bug (JM-5051) fix court visibility of court owned jurors in inactive pools

### DIFF
--- a/client/templates/pool-management/pool-overview/court-pool-jurors.njk
+++ b/client/templates/pool-management/pool-overview/court-pool-jurors.njk
@@ -69,11 +69,11 @@
           {% include "./_partials/filters.njk" %}
         </div>
 
-        {% if poolMembers.length === 0 and poolDetails.isActive === true %}
+        {% if poolMembers.length === 0 %}
           <div id="pool-overview-table-wrapper" class="govuk-grid-column-full">
             <span class="govuk-body">There are no results to display.</span>
           </div>
-        {% elif poolDetails.isActive === true %}
+        {% else %}
           <div id="pool-overview-table-wrapper" class="govuk-grid-column-full">
 
             {% if errors.items["selectedJurors"] %}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-5051

### Change description ###

Makes it so that court users can see jurors they own in bureau owned pools.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
