### PR TITLE
hotfix/JM-6970: Padding expenses travel time for API

### DIFF
--- a/client/js/expenses-summary.js
+++ b/client/js/expenses-summary.js
@@ -80,8 +80,8 @@
   }
 
   function attendance(data) {
-    var totalTravelTimeHour = $('#totalTravelTime-hour').val();
-    var totalTravelTimeMinute = $('#totalTravelTime-minute').val();
+    var totalTravelTimeHour = $('#totalTravelTime-hour').val().padStart(2, '0');
+    var totalTravelTimeMinute = $('#totalTravelTime-minute').val().padStart(2, '0');
     var attendanceType = $('input[name="payAttendance"]:checked').val();
 
     data.time = {

--- a/server/routes/juror-management/expenses/edit/edit-approval-expenses.controller.js
+++ b/server/routes/juror-management/expenses/edit/edit-approval-expenses.controller.js
@@ -773,7 +773,7 @@
         'pay_cash': body.paymentMethod === 'CASH',
         time: {
           'pay_attendance': body.payAttendance,
-          'travel_time': body['totalTravelTime-hour'] + ':' + body['totalTravelTime-minute'],
+          'travel_time': body['totalTravelTime-hour'].padStart(2, '0') + ':' + body['totalTravelTime-minute'].padStart(2, '0'),
         },
         travel: {
           'traveled_by_car': false,

--- a/server/routes/juror-management/expenses/enter-expenses/enter-expenses.controller.js
+++ b/server/routes/juror-management/expenses/enter-expenses/enter-expenses.controller.js
@@ -551,7 +551,8 @@
         'pay_cash': body.paymentMethod === 'CASH',
         time: {
           'pay_attendance': body.payAttendance,
-          'travel_time': body['totalTravelTime-hour'] + ':' + body['totalTravelTime-minute'],
+          'travel_time': body['totalTravelTime-hour'].padStart(2, '0')
+            + ':' + body['totalTravelTime-minute'].padStart(2, '0'),
         },
         travel: {
           'traveled_by_car': false,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6970

### Change description ###

Padded travel time for entering/editing expenses as not to error out on API if you enter '3:30' rather than '03:30'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
