### PR TITLE
hotfix/JM-6776: Lock expense approval to court managers only

### DIFF
--- a/client/templates/juror-management/_common/juror-management-nav.njk
+++ b/client/templates/juror-management/_common/juror-management-nav.njk
@@ -39,7 +39,8 @@
       attributes: {
         id: "unpaidAttencanceAnchor"
       }
-    },
+    }
+  ]).concat([
     {
       text: "Approve expenses",
       href: url("juror-management.approve-expenses.get"),
@@ -48,7 +49,7 @@
         id: "expensesAnchor"
       }
     }
-  ])
+  ] if isCourtManager else [])
 %}
 
 {{ mojPrimaryNavigation({

--- a/server/routes/juror-management/approve-expenses/index.js
+++ b/server/routes/juror-management/approve-expenses/index.js
@@ -3,42 +3,49 @@
 
   const controller = require('./approve-expenses.controller');
   const auth = require('../../../components/auth');
+  const { isCourtManager } = require('../../../components/auth/user-type');
 
   module.exports = function(app) {
 
     app.get('/juror-management/approve-expenses',
       'juror-management.approve-expenses.get',
       auth.verify,
+      isCourtManager,
       controller.getApproveExpenses(app),
     );
 
     app.post('/juror-management/approve-expenses',
       'juror-management.approve-expenses.post',
       auth.verify,
+      isCourtManager,
       controller.postApproveExpenses(app),
     );
 
     app.post('/juror-management/approve-expenses/filter',
       'juror-management.approve-expenses.filter-dates.post',
       auth.verify,
+      isCourtManager,
       controller.postFilterByDate(app),
     );
 
     app.get('/juror-management/approve-expenses/cannot-approve',
       'juror-management.approve-expenses.cannot-approve.get',
       auth.verify,
+      isCourtManager,
       controller.getCannotApprove(app)
     );
 
     app.post('/juror-management/approve-expenses/cannot-approve',
       'juror-management.approve-expenses.cannot-approve.post',
       auth.verify,
+      isCourtManager,
       controller.postCannotApprove(app)
     );
 
     app.get('/juror-management/approve-expenses/view-expenses/:jurorNumber/:poolNumber/:status',
       'juror-management.approve-expenses.view-expenses.get',
       auth.verify,
+      isCourtManager,
       controller.getViewExpenses(app),
     );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6776

### Change description ###

Locked expense approval to court managers only

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
