### PR TITLE
Court Users - Hide pool history tab until transferred to court

### DIFF
--- a/client/templates/pool-management/pool-overview/_partials/sub-nav.njk
+++ b/client/templates/pool-management/pool-overview/_partials/sub-nav.njk
@@ -22,7 +22,7 @@
         attributes: {
           id: "historyTab"
         }
-      }]
+      } if isBureauUser or currentOwner !== "400" ]
     }) }}
   </div>
 </div>

--- a/server/routes/pool-management/pool-overview/pool-overview.controller.js
+++ b/server/routes/pool-management/pool-overview/pool-overview.controller.js
@@ -507,6 +507,7 @@ const filters = require('../../../components/filters');
           poolSummary: data.poolSummary,
           additionalStatistics: data.additionalStatistics,
           isNil: data.poolDetails.is_nil_pool,
+          currentOwner: data.poolDetails.current_owner,
           currentTab: 'history',
           navData: _.clone(req.session.poolManagementNav),
         });
@@ -688,6 +689,7 @@ const filters = require('../../../components/filters');
         poolDetails: pool.poolDetails,
         isNil: pool.poolDetails.is_nil_pool,
         isActive: pool.isActive,
+        currentOwner: pool.poolDetails.current_owner,
         currentTab: 'jurors',
         postUrls: { assignUrl, transferUrl, completeServiceUrl, changeServiceDateUrl, postponeUrl },
         navData: _.clone(req.session.poolManagementNav),


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6933

### Change description ###

Hide pool history tab for all court users until the pool has been transferred to court.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
