### PR TITLE
hotfix/JM-7045

### DIFF
--- a/client/templates/summons-management/_common/details-banner-new.njk
+++ b/client/templates/summons-management/_common/details-banner-new.njk
@@ -82,7 +82,7 @@
         </div>
         <div class="govuk-grid-column-one-third">
           <div class="label info">Reply method</div>
-          <div class="info">{{ (method or response.replyMethod) | capitalizeFully }}</div>
+          <div class="info">{{ (response.replyMethod or method) | capitalizeFully }}</div>
         </div>
         {% if response.welshCourt %}
           <div class="govuk-grid-column-one-third">

--- a/server/routes/response/detail/detail.controller.js
+++ b/server/routes/response/detail/detail.controller.js
@@ -379,7 +379,7 @@
 
                 opticReference,
                 processedBannerMessage: data.processedBannerMessage ? data.processedBannerMessage : null,
-                method: 'paper',
+                method: 'digital',
               });
             });
         }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7045

### Change description ###

Update to use replyMethod to display the reply method in summons detail rather than the method from URL as first choice as this is showing paper for digital responses.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
