### PR TITLE
hotfix/JM-7129 - Bureau able to process a court-owned reply

### DIFF
--- a/server/routes/summons-management/index.js
+++ b/server/routes/summons-management/index.js
@@ -19,57 +19,69 @@
     app.get('/summons-replies/response/:id/:type(paper|digital)/process',
       'process-reply.get',
       auth.verify,
+      processController.checkOwner(app),
       processController.getProcessReply(app));
     app.post('/summons-replies/response/:id/:type(paper|digital)/process',
       'process-reply.post',
       auth.verify,
+      processController.checkOwner(app),
       processController.postProcessReply(app));
 
     app.get('/summons-replies/response/:id/:type(paper|digital)/deferral-dates',
       'process-deferral-dates.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getDeferralDates(app));
 
     app.post('/summons-replies/response/:id/:type(paper|digital)/deferral-dates-post',
       'process-deferral-dates.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postDeferralDates(app));
 
     app.get('/summons-replies/response/:id/:type(paper|digital)/deferral',
       'process-deferral.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getDeferral(app));
 
     app.post('/summons-replies/response/:id/:type(paper|digital)/deferral',
       'process-deferral.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postDeferral(app));
 
     app.get('/summons-replies/response/:id/:type(paper|digital)/deferral/letter',
       'process-deferral.letter.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getDeferralLetter(app));
     app.post('/summons-replies/response/:id/:type(paper|digital)/deferral/letter',
       'process-deferral.letter.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postDeferralLetter(app));
 
     app.get('/summons-replies/response/:id/:type(paper|digital)/excusal',
       'process-excusal.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getExcusal(app));
     app.post('/summons-replies/response/:id/:type(paper|digital)/excusal',
       'process-excusal.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postExcusal(app));
 
     app.get('/summons-replies/response/:id/:type(paper|digital)/excusal/:letter(grant|refuse)/letter',
       'process-excusal.letter.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getExcusalLetter(app));
     app.post('/summons-replies/response/:id/:type(paper|digital)/excusal/:letter(grant|refuse)/letter',
       'process-excusal.letter.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postExcusalLetter(app));
 
     app.get('/summons-replies/response/:id/:type(paper)',
@@ -80,10 +92,12 @@
     app.get('/summons-replies/response/:id/check-can-accommodate',
       'response.check-can-accommodate.get',
       auth.verify,
+      processController.checkOwner(app),
       controller.getCheckCanAccommodate(app));
     app.post('/summons-replies/response/:id/check-can-accomodate',
       'response.check-can-accommodate.post',
       auth.verify,
+      processController.checkOwner(app),
       controller.postCheckCanAccommodate(app));
   };
 

--- a/server/routes/summons-management/process-reply/process-reply.controller.js
+++ b/server/routes/summons-management/process-reply/process-reply.controller.js
@@ -17,7 +17,6 @@ module.exports.checkOwner = function(app) {
         app,
         req.session.authToken,
         req.params['id'],
-        req.session.hasModAccess,
       );
 
       const currentOwner = req.params['type'] === 'paper' ?

--- a/server/routes/summons-management/process-reply/process-reply.controller.js
+++ b/server/routes/summons-management/process-reply/process-reply.controller.js
@@ -5,6 +5,19 @@ const _ = require('lodash');
 const summonsValidator = require('../../../config/validation/summons-management');
 const validate = require('validate.js');
 
+module.exports.checkOwner = function(app) {
+  return function(req, res, next) {
+    if (req.session.jurorCommonDetails.owner !== req.session.authentication.locCode) {
+      app.logger.crit('Current user does not have sufficient permission to process this summons reply: ', {
+        auth: req.session.authentication,
+        jwt: req.session.authToken,
+      });
+      return res.status(403).render('_errors/403.njk');
+    }
+    next();
+  };
+};
+
 module.exports.getProcessReply = function(app) {
   return function(req, res) {
     var tmpErrors = _.clone(req.session.errors)


### PR DESCRIPTION
### JIRA link ###

[JM-7129 - UAT - letting Bureau process a reply once it is in court control 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7129)

### Description ###

- Add check to see if the juror's and current user's owner values match.

The only way I could replicate this bug was by (as a Court user) going to a court-owned juror's summons reply, click on the Process reply button (the button itself is only available if the juror's owner matches the user's auth owner value), then copying the link in the URL bar, log out and log in as a Bureau user, and pasting the link in the browser.

Spoke to Liam - he mentioned this bug came up during UAT after a data load (to which I have no access to).

The fix prevents unauthorised access to the 'Process reply' process regardless by checking the owner values.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
