### PR TITLE
hotfix/JM-7126 - Missing back link on Summons Reply page

### DIFF
--- a/client/templates/response/detail.njk
+++ b/client/templates/response/detail.njk
@@ -5,6 +5,7 @@
 {% from "../includes/reply-type-tag-macro.njk" import replyTypeTag %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block page_title %}
   {{ serviceName }} - response details
@@ -15,6 +16,15 @@
 {% set currentApp = "Summons replies" %}
 
 {% block beforeContent %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: url('inbox.todo.get'),
+    attributes: {
+      id: "backLinkAnchor"
+    }
+  }) }}
+
   {% if response.processingStatus === 'Closed' %}
     <div class="govuk-!-margin-top-3">
       {% set bannerMessageHtml %}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JM-7126 - UAT - No back button on after clicking on a summons reply 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7126)

### Description ###

- Added a Back link on the summons reply page.

As discussed with Liam, the 'Back' link will take the user back to their inbox page.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
