### PR TITLE
show urgent label for urgent and super urgent responses that are clos…

### DIFF
--- a/client/templates/response/detail.njk
+++ b/client/templates/response/detail.njk
@@ -64,9 +64,9 @@
 {% block content %}
 
   {# set alert badge - as displayed on To do list #}
-  {% if response.processingStatus !== 'Closed' and response.isLateSummons %}
+  {% if response.processingStatus !== "Closed" %}
     {% if response.superUrgent %}
-      {% set urgencyBadge = "Urgent" if method === "paper" else "Send to court" %}
+      {% set urgencyBadge = "Urgent" %}
     {% elif response.urgent %}
       {% set urgencyBadge = "Urgent" %}
     {% elif response.slaOverdue %}


### PR DESCRIPTION
- show `urgent` for both paper and digital replies
- remove `send to court` label