### PR TITLE
hotfix/JM-7153 - Missing 'Edit pool' button for Court users

### DIFF
--- a/client/templates/pool-management/pool-overview/court-pool-overview.njk
+++ b/client/templates/pool-management/pool-overview/court-pool-overview.njk
@@ -61,6 +61,19 @@
       </div>
     </div>
 
+    <span>
+      {{ govukButton({
+        text: "Edit pool",
+        href: url('pool-management.edit-pool.get', {
+          poolNumber: poolDetails.poolNumber
+        }),
+        classes: "govuk-button--secondary govuk-!-margin-bottom-0",
+        attributes: {
+          id: "editPoolButton"
+        }
+      }) }}
+    </span>
+
   </div>
 
   <div class="court-details-wrapper">

--- a/server/routes/pool-management/pool-overview/edit/edit-pool.controller.js
+++ b/server/routes/pool-management/pool-overview/edit/edit-pool.controller.js
@@ -72,9 +72,9 @@
             title: 'Pool not found',
             message: 'The pool you are trying to edit does not exist',
           });
-        }
+        };
 
-      tmpErrors = _.clone(req.session.errors)
+      tmpErrors = _.clone(req.session.errors);
       delete req.session.errors;
       delete req.session.formFields;
 
@@ -86,8 +86,8 @@
       )
         .then(successCB)
         .catch(errorCB);
-    }
-  }
+    };
+  };
 
   module.exports.post = function(app) {
     return function(req, res) {
@@ -109,7 +109,7 @@
 
           return res.redirect(app.namedRoutes.build('pool-overview.get', {
             poolNumber: req.params['poolNumber'],
-          }))
+          }));
         }
         , errorCB = function(err) {
 
@@ -128,7 +128,7 @@
           req.session.postError = 'Something went wrong. Please check your form and try again';
 
           return res.redirect(app.namedRoutes.build('pool-management.edit-pool.get', {
-            poolNumber: req.params['poolNumber']
+            poolNumber: req.params['poolNumber'],
           }));
         }
         , bodyKey;
@@ -151,7 +151,7 @@
         req.session.formFields = req.body;
 
         return res.redirect(app.namedRoutes.build('pool-management.edit-pool.get', {
-          poolNumber: req.params['poolNumber']
+          poolNumber: req.params['poolNumber'],
         }));
       }
 
@@ -164,7 +164,7 @@
       )
         .then(successCB)
         .catch(errorCB);
-    }
-  }
+    };
+  };
 
 })();

--- a/server/routes/pool-management/pool-overview/pool-overview.controller.js
+++ b/server/routes/pool-management/pool-overview/pool-overview.controller.js
@@ -68,6 +68,7 @@ const filters = require('../../../components/filters');
       delete req.session.selectedJurors;
       delete req.session.selectedAll;
       delete req.session.processLateSummons;
+      delete req.session.editPool;
 
       poolSummaryObj.get(
         rp,


### PR DESCRIPTION
### JIRA link ###

[JM-7153 - No edit pool button for court users on pool requests or active pools 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7153)

### Description ###

Court users should be able to edit requested and active pools, regardless of the pool's owner.

- Added 'Edit pool' button for Court users.

BE PR: https://github.com/hmcts/juror-api/pull/278

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
