### PR TITLE
Export details - data items all deselected by default

### DIFF
--- a/client/templates/messaging/export-contact-details/details-to-export.njk
+++ b/client/templates/messaging/export-contact-details/details-to-export.njk
@@ -35,55 +35,68 @@
           items: [
             {
               value: "JUROR_NUMBER",
-              text: "Juror number"
+              text: "Juror number",
+              checked: true
             },
             {
               value: "TITLE",
-              text: "Title"
+              text: "Title",
+              checked: true
             },
             {
               value: "FIRST_NAME",
-              text: "First name"
+              text: "First name",
+              checked: true
             },
             {
               value: "LAST_NAME",
-              text: "Last name"
+              text: "Last name",
+              checked: true
             },
             {
               value: "EMAIL",
-              text: "Email"
+              text: "Email",
+              checked: true
             },
             {
               value: "MAIN_PHONE",
-              text: "Main phone"
+              text: "Main phone",
+              checked: true
             },
             {
               value: "OTHER_PHONE",
-              text: "Other phone"
+              text: "Other phone",
+              checked: true
             },
             {
               value: "WORK_PHONE",
-              text: "Work phone"
+              text: "Work phone",
+              checked: true
             },
             {
               value: "ADDRESS",
-              text: "Address"
+              text: "Address",
+              checked: true
             },
             {
               value: "POSTCODE",
-              text: "Postcode"
+              text: "Postcode",
+              checked: true
             },
             {
               value: "STATUS",
-              text: "Status"
+              text: "Status",
+              checked: true
             },
             {
               value: "POOL_NUMBER",
-              text: "Pool number"
+              text: "Pool number",
+              checked: true
             },
             {
               value: "DATE_DEFERRED_TO",
-              text: "Date deferred to"
+              text: "Date deferred to",
+              checked: true
             }
           ]
         }) }}
@@ -153,12 +166,8 @@
         if (defaultDetailsToExport) {
           const detailsToExportArray = JSON.parse(defaultDetailsToExport);
 
-          detailsToExportArray.forEach((detail) => {
-            detailsToExport.forEach((detailCheckbox) => {
-              if (detailCheckbox.value === detail) {
-                detailCheckbox.checked = true;
-              }
-            });
+          detailsToExport.forEach((detailCheckbox) => {
+            detailCheckbox.checked = detailsToExportArray.includes(detailCheckbox.value);
           });
         }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7169)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=311)


### Change description ###
All deselected by default. In heritage, they are all selected by default. Is that correct - is it more useful to users to have them all selected?

!image-20240430-103317.png|width=676,height=778,alt="image-20240430-103317.png"!

!image-20240430-103458.png|width=1381,height=261,alt="image-20240430-103458.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
