### PR TITLE
Single juror record on search does not redirect to the juror record page

### DIFF
--- a/client/templates/juror-management/search/index.njk
+++ b/client/templates/juror-management/search/index.njk
@@ -85,7 +85,7 @@
         <li>double-checking your spelling</li>
       </ul>
     {% elif jurorRecords.length > 0 %}
-      <h2>{{ totalResults }} {{ "results" if totalResults > 1 else "result" }}</h2>
+      <h2>{{ totalResults }} results</h2>
 
       {% include "./results-list.njk" %}
 

--- a/server/routes/juror-management/search/search.controller.js
+++ b/server/routes/juror-management/search/search.controller.js
@@ -22,6 +22,15 @@ module.exports.getSearch = function(app) {
       try {
         const response = await searchJurorRecordDAO.post(req, payload);
 
+        if (response.total_items === 1 && response.data.length === 1) {
+          const jurorRecord = response.data[0];
+          const jurorRecordUrl = urljoin(app.namedRoutes.build('juror-record.select.get'),
+            '?jurorNumber=' + jurorRecord.juror_number,
+            '&locCode=' + jurorRecord.loc_code);
+
+          return res.redirect(jurorRecordUrl);
+        }
+
         totalResults = response.total_items;
         jurorRecords = transformResults(response.data, app.namedRoutes);
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7182)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=315)


### Change description ###
Single juror result shows a table but should redirect to the juror record

!image-20240430-162303.png|width=1543,height=933,alt="image-20240430-162303.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
