### PR TITLE
fix a missing comma on a nunjucks macro

### DIFF
--- a/client/templates/administration/users/create-users/confirm-details.njk
+++ b/client/templates/administration/users/create-users/confirm-details.njk
@@ -29,7 +29,7 @@
                   {
                     href: changeUserTypeUrl,
                     text: "Change",
-                    visuallyHiddenText: "userType"
+                    visuallyHiddenText: "userType",
                     attributes: {
                       "aria-label": "Change user type"
                     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
fix a comma breaking a nunjucks template for gone missing


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
