### PR TITLE
Login to Azure - As a user I need to be able to sign in to the system (FE)

### DIFF
--- a/client/templates/layouts/govuk_template.njk
+++ b/client/templates/layouts/govuk_template.njk
@@ -93,7 +93,7 @@
                   </span>
                 </li>
                 <li class="moj-header__navigation-item moj-header__navigation-item--without-children">
-                  <a class="moj-header__navigation-link" href="{{ url('login.get') }}">Sign out</a>
+                  <a class="moj-header__navigation-link" href="{{ url('login.get') if env === 'development' else url('authentication.logout.get') }}">Sign out</a>
                 </li>
               </ul>
             {% endif %}

--- a/client/templates/sign-in.njk
+++ b/client/templates/sign-in.njk
@@ -22,7 +22,7 @@
 
     {{ govukButton({
       text: "Sign in",
-      href: "#",
+      href: url("authentication.azure.get"),
       classes: "govuk-button--start"
     }) }}
 

--- a/config/environment.template.json
+++ b/config/environment.template.json
@@ -9,10 +9,17 @@
       "bureau-smartSurveyTokenSecret": "",
       "launchDarklyKey": "very-secure-key",
       "app-insights-connection-string": "very-secure-key",
-      "bureau-redisConnection": "redis://localhost:6379",
-      "azure-app-id": "",
-      "azure-tenant-id": "",
-      "azure-app-secret": ""
+      "bureau-redisConnection": "redis://localhost:6379"
+    },
+    "azure": {
+      "app-id": "",
+      "tenant-id": "",
+      "client-secret": "",
+      "auth-url": "",
+      "claims": "",
+      "callback-url": "",
+      "graph-url": "",
+      "logout-redirect": ""
     }
   }
 }

--- a/server/lib/session-config.js
+++ b/server/lib/session-config.js
@@ -74,7 +74,7 @@ module.exports.SessionConfig = class SessionConfig {
       name: 'juror_bureau_session',
       cookie: {
         secure: isProduction,
-        sameSite: true,
+        sameSite: 'lax', // oauth redirect does not work with strict
         httpOnly: true,
       },
     };

--- a/server/routes/authentication/azure.controller.js
+++ b/server/routes/authentication/azure.controller.js
@@ -1,0 +1,94 @@
+/* eslint-disable strict */
+const secretsConfig = require('config');
+const axios = require('axios');
+
+module.exports.getAzureAuth = function(app) {
+  return function(_, res) {
+    app.logger.debug('Redirecting to Azure for authentication');
+
+    const { authUrl, queryParams } = buildAzureUrl('authorize');
+
+    return res.redirect(`${authUrl}?${queryParams.toString()}`);
+  };
+};
+
+module.exports.getAzureCallback = function(app) {
+  return async function(req, res) {
+    const graphUrl = secretsConfig.get('secrets.azure.graph-url');
+
+    const { code } = req.query;
+    const { authUrl, queryParams } = buildAzureUrl('token', code);
+    const payload = {};
+
+    queryParams.forEach((value, key) => {
+      payload[key] = value;
+    });
+
+    const authResponse = await axios.post(authUrl, payload, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+
+    const response = await axios.get(graphUrl, {
+      headers: {
+        Authorization: 'Bearer ' + authResponse.data.access_token,
+      },
+    });
+
+    req.session.email = response.data.mail.toLowerCase();
+
+    return res.redirect(app.namedRoutes.build('authentication.courts-list.get'));
+  };
+};
+
+module.exports.getAzureLogout = function(app) {
+  return function(req, res) {
+    const tenantId = secretsConfig.get('secrets.azure.tenant-id');
+    const authUrl = secretsConfig.get('secrets.azure.auth-url').replace('{tenant_id}', tenantId);
+    const logoutRedirect = secretsConfig.get('secrets.azure.logout-redirect');
+
+    app.logger.debug('Redirecting to Azure for logout', {
+      auth: req.session.authentication,
+    });
+
+    req.session.destroy((err) => {
+      if (err) {
+        app.logger.error('Error destroying session', err);
+
+        return res.redirect('login.get');
+      }
+
+      return res.redirect(`${authUrl}/logout?post_logout_redirect_uri=${logoutRedirect}`);
+    });
+  };
+};
+
+function buildAzureUrl(/** @type {'authorize' | 'token'} */pathPart, code) {
+  const clientId = secretsConfig.get('secrets.azure.app-id');
+  const tenantId = secretsConfig.get('secrets.azure.tenant-id');
+  const authUrl = secretsConfig.get('secrets.azure.auth-url').replace('{tenant_id}', tenantId);
+  const claims = secretsConfig.get('secrets.azure.claims');
+  const cbUrl = secretsConfig.get('secrets.azure.callback-url');
+
+  const queryParams = new URLSearchParams();
+
+  queryParams.append('client_id', clientId);
+  queryParams.append('scope', claims);
+  queryParams.append('response_type', 'code');
+  queryParams.append('redirect_uri', cbUrl);
+
+  if (pathPart === 'authorize') {
+    queryParams.append('prompt', 'select_account');
+  }
+
+  if (pathPart === 'token' && code) {
+    const clientSecret = secretsConfig.get('secrets.azure.client-secret');
+
+    queryParams.append('client_secret', clientSecret);
+    queryParams.append('code', code);
+    queryParams.append('grant_type', 'authorization_code');
+  }
+
+  return { authUrl: `${authUrl}/${pathPart}`, queryParams };
+}

--- a/server/routes/authentication/index.js
+++ b/server/routes/authentication/index.js
@@ -1,9 +1,22 @@
 /* eslint-disable strict */
 
 const controller = require('./authentication.controller');
+const azureController = require('./azure.controller');
 const { isSystemAdministrator } = require('../../components/auth/user-type');
 
 module.exports = function(app) {
+
+  app.get('/auth/internal/azure',
+    'authentication.azure.get',
+    azureController.getAzureAuth(app));
+
+  app.get('/auth/internal/callback',
+    'authentication.azure.callback',
+    azureController.getAzureCallback(app));
+
+  app.get('/auth/internal/logout',
+    'authentication.logout.get',
+    azureController.getAzureLogout(app));
 
   app.get('/auth/courts-list',
     'authentication.courts-list.get',


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6386)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=329)


### Change description ###


acceptance criteria:

|JMUMM 03:|The system shall enable administrators, court and bureau officers to sign in to the system|
|Requirement Description|The system shall enable administrators, court and bureau officers to sign in to the system
       I.         The system shall display a sign in and button and the following message ‘If you need access to this service. Speak to your manager or contact Crown IT support (hyperlink from contact to support)
     II.         The system shall use Microsoft single sign on and ask the officer to enter their email and password the first time they sign on
    III.         The system shall remember the users sign in details after they have logged on once
   IV.         For Court and administrators the system shall ask the user what court they want to manage when they log in and display all courts they have access too
     V.         The system shall allow the officer to change what court they are signed in to and take then back to that screen once signed into the app|
|Owner|Product Owner|
|Additional Details|*Existing Juror heritage Screens*
[Request a pool - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949218324/Request+a+pool]
*Data type for user inputs*
# N/A, system generated
# N/A, system generated
# N/A, system generated
 
 
*High level requirements*
N/A
 
*New Screen Design*
 
[Global (SPEC) – Figma|https://www.figma.com/file/VvXEMYpi0Vl14lk05Y0Kxi/Global-(SPEC)?type=design&node-id=0-1&mode=design&t=86Yl1HxlPCF3SyH1-0]|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
