### PR TITLE
Internal server error where juror's postcode exists in >1 court_catchment_area

### DIFF
--- a/client/templates/response/_partials/call-logs.njk
+++ b/client/templates/response/_partials/call-logs.njk
@@ -9,7 +9,7 @@
         <h2 class="govuk-heading-m">Contact log</h2>
 
         <div class="govuk-body">
-          <a id="notesEditButton" class="govuk-link" href="{{ url('response.contact-logs.add.get', { id: response.jurorNumber, type: method }) }}">Log new contact</a>
+          <a id="notesEditButton" class="govuk-link" href="{{ url('response.contact-logs.add.get', { id: response.jurorNumber, type: method or 'digital' }) }}">Log new contact</a>
         </div>
       </div>
 

--- a/client/templates/response/_partials/notes.njk
+++ b/client/templates/response/_partials/notes.njk
@@ -10,7 +10,7 @@
           <a id="notesEditButton"
              class="govuk-link"
              aria-label="Add or change notes"
-             href="{{ url('response.notes.edit.get', { id: response.jurorNumber, type: method }) }}"
+             href="{{ url('response.notes.edit.get', { id: response.jurorNumber, type: method or 'digital' }) }}"
           >
             Add or change
           </a>

--- a/client/templates/summons-management/_partials/signature.njk
+++ b/client/templates/summons-management/_partials/signature.njk
@@ -12,7 +12,7 @@
             classes: "govuk-tag" if response.signed === true else "govuk-tag--grey"
           }) }}
         </h2>
-        {% if isAddChangeVisible %}
+        {% if method === "paper" and isAddChangeVisible %}
           <div class="govuk-body">
             <a id="signatureEdit" 
                class="govuk-link"


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7225)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=330)


### Change description ###
BAU regression test {{Scenario Outline: Change postcode - old postcode in >1 loc_code SHOWS CHANGE COURT}}

Juror is summoned with postcode {{SY2 6LU}} - SY2 exists in court_catchment_area in 2 loc_codes:

!image-20240507-101322.png|width=638,height=170,alt="image-20240507-101322.png"!

When I search for this response, then select the response from search results, I get 

!image-20240507-101401.png|width=516,height=116,alt="image-20240507-101401.png"!

Same result if I nav to the response via the juror record.

Logs reporting the following, but Im not sure whether that is a red herring: Juror: 045200185. Cannot find paper response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
