### PR TITLE
hotfix/JM-7123 - Existing email FE error handling

### DIFF
--- a/client/templates/administration/users/create-users/confirm-details.njk
+++ b/client/templates/administration/users/create-users/confirm-details.njk
@@ -13,6 +13,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      
+      {% include "includes/errors.njk" %}  
+      
       <h1 class="govuk-heading-xl">Check {{'edited' if editingUser else 'new'}} user details</h1>
       <form action="{{ processUrl }}" method="post" id="confirmDetailsForm">
         {{ govukSummaryList({


### PR DESCRIPTION
### JIRA link ###

[JM-7123 - If I try to create a user with an email that is already recorded against a user: "Sorry, there is a technical problem" 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7123)

### Description ###

- Added FE error handling for when an email address is already in use.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
