### PR TITLE
hotfix/JM-7214 - 'Summoned' jurors should not have their next due changed (Juror record).

### DIFF
--- a/client/templates/juror-management/juror-record/attendance.njk
+++ b/client/templates/juror-management/juror-record/attendance.njk
@@ -73,7 +73,7 @@
                   }
                 }
               ]
-            }
+            } if isCourtUser and juror.commonDetails.jurorStatus === "Responded"
           },
           {
             key: {


### PR DESCRIPTION
### JIRA link ###

[JM-7214 - Can set next due at court date for jurors not in 'summoned' status from Juror Record 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7214)

### Change description ###

- Made 'Change' link only available if the Juror has status "Responded".

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
