### PR TITLE
2 links with text "Advanced search" on search page

### DIFF
--- a/client/templates/custom-components/super-navigation/super-navigation.njk
+++ b/client/templates/custom-components/super-navigation/super-navigation.njk
@@ -107,7 +107,9 @@
       }) }}
 
       <p class="govuk-body">
-        <a class="govuk-link" href="{{ url('juror-record.search.get') }}">Advanced search</a>
+        <a class="govuk-link" href="{{ url('juror-record.search.get') }}" aria-label="Advanced juror search">
+          Advanced juror search
+        </a>
       </p>
 
     </div>


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7246)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=336)


### Change description ###
[https://juror.staging.apps.hmcts.net/search|https://juror.staging.apps.hmcts.net/search] page has 2 links with text “Advanced Search”


!image-20240508-134251.png|width=1294,height=779,alt="image-20240508-134251.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
