### PR TITLE
hotfix/JM-7165 - Sending juror messages causing technical error

### DIFF
--- a/server/routes/messaging/send-messages.controller.js
+++ b/server/routes/messaging/send-messages.controller.js
@@ -655,7 +655,7 @@
 
         await sendMessage.post(
           app,
-          req,
+          req.session.authToken,
           messagingCodes[message],
           req.session.authentication.owner,
           payload,


### PR DESCRIPTION
### JIRA link ###

[JM-7165 - Sending juror messages causing technical error 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7165)

### Description ###

- Corrected wrongly parsed JWT token for API call.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
