### PR TITLE
Attendance details on unpaid attendance incorrect after returning jury

### DIFF
--- a/client/templates/juror-management/expense-record/_partials/expenses-table-macros.njk
+++ b/client/templates/juror-management/expense-record/_partials/expenses-table-macros.njk
@@ -67,6 +67,7 @@
 {% endmacro %}
 
 {% macro attendanceType(params) %}
+  {% set attendanceType = "" %}
   {% if params.attendance === "FULL_DAY" %}
     {% set attendanceType = "Full day" %}
   {% elif params.attendance === "HALF_DAY" %}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7262)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=342)


### Change description ###
When returning a jury and confirming attendance, the jurors attendance details on the unpaid attendance screen appear incorrect. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
