### PR TITLE
Summons Reply - Juror details Email field doesn't have the same structure

### DIFF
--- a/client/templates/response/_partials/juror-details.njk
+++ b/client/templates/response/_partials/juror-details.njk
@@ -198,20 +198,20 @@
           Email 
         </dt>
         {% if jurorDetails.email.current === null %}
-          <td class="govuk-summary-list__value" id="jurorEmailAddress">-</td>
+          <dd class="govuk-summary-list__value" id="jurorEmailAddress">-</dd>
         {% else %}
-          <td class="govuk-summary-list__value" id="jurorEmailAddress">
+          <dd class="govuk-summary-list__value" id="jurorEmailAddress">
             {% if jurorDetails.email.changed %}
               <div class="jd-label-blue">New</div>
             {% endif %}
             {{ jurorDetails.email.current }}
-          </td>
-          <td class="govuk-summary-list__value" id="oldJurorEmailAddress">
+          </dd>
+          <dd class="govuk-summary-list__value" id="oldJurorEmailAddress">
             {% if jurorDetails.email.changed %}
               <div class="jd-label-black">Previous</div>
             {% endif %}
             {{ jurorDetails.email.old }}
-          </td>
+          </dd>
         {% endif %}
       </div>
     </dl>


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7252)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=344)


### Change description ###
The ‘Email’ field on the Juror details doesn’t have the same structure as the other fields. From the tests it looks like it did at some point but the ID which was 'jurorEmailAddress' has been lost.



!image-20240509-100138.png|width=490,height=191,alt="image-20240509-100138.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
