### PR TITLE
hotfix/JM-7205 - Bureau user (non-manager) can assign response to another user

### DIFF
--- a/client/templates/response/_partials/update-header.njk
+++ b/client/templates/response/_partials/update-header.njk
@@ -5,6 +5,12 @@
     <div class="reply-view-header-menus">
 
       {% set canProcessReply = false %}
+
+      {% if response.replyMethod === "DIGITAL" %}
+        {% set assignedStaffMember = response.assignedStaffMember.login %}
+      {% elif method === "paper" %}
+        {% set assignedStaffMember = response.assignedStaffMember.username %}
+      {% endif %}
       
       {% if response.current_owner === authentication.owner %}
         {% set canProcessReply = true %}
@@ -52,7 +58,7 @@
                     Request juror info by post
                   </a>
 
-                  {% if response.assignedStaffMember.login === authentication.login or authentication.staff.rank === 1 %}
+                  {% if assignedStaffMember === authentication.login or isManager %}
                     {% set sendToUrl = url('response.assign.get', { id: response.jurorNumber }) + "?reply_method=" + method %}
                     <a id="processSendTo" href="{{ sendToUrl }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " value="send_to" data-module="govuk-button">
                       Send to a colleague...

--- a/client/templates/response/_partials/update-header.njk
+++ b/client/templates/response/_partials/update-header.njk
@@ -52,10 +52,12 @@
                     Request juror info by post
                   </a>
 
-                  {% set sendToUrl = url('response.assign.get', { id: response.jurorNumber }) + "?reply_method=" + method %}
-                  <a id="processSendTo" href="{{ sendToUrl }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " value="send_to" data-module="govuk-button">
-                    Send to a colleague...
-                  </a>
+                  {% if response.assignedStaffMember.login === authentication.login or authentication.staff.rank === 1 %}
+                    {% set sendToUrl = url('response.assign.get', { id: response.jurorNumber }) + "?reply_method=" + method %}
+                    <a id="processSendTo" href="{{ sendToUrl }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " value="send_to" data-module="govuk-button">
+                      Send to a colleague...
+                    </a>
+                  {% endif %}
                 {% endif %}
 
               {% endif %}


### PR DESCRIPTION
### JIRA link ###

[JM-7205 - Bureau user (non manager) can assign response to another user 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7205)

### Description ###

- Restricted the 'Send to colleague...' link to the assigned user only and Bureau managers.

**Does this PR introduce a breaking change?** 

```
[ ] Yes
[x] No
```
