### PR TITLE
hotfix/JM-7219 - Time created incorrect on reports

### DIFF
--- a/server/routes/reporting/standard-report/utils.js
+++ b/server/routes/reporting/standard-report/utils.js
@@ -35,10 +35,10 @@ const headingDataMappers = {
   timeFromISO: (data) => {
     const time = data.split('T')[1].split('.')[0];
 
-    if (time.split(':')[0] === 12) {
+    if (parseInt(time.split(':')[0]) === 12) {
       return time + 'pm';
-    } else if (time.split(':')[0] > 12) {
-      return `${time.split(':')[0] - 12}:${time.split(':').slice(1).join(':')}pm`;
+    } else if (parseInt(time.split(':')[0]) > 12) {
+      return `${parseInt(time.split(':')[0]) - 12}:${time.split(':').slice(1).join(':')}pm`;
     }
 
     return time + 'am';


### PR DESCRIPTION
### JIRA link###

[JM-7219 - Time created incorrect on reports 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7219)

### Description ###

- Fixed wrongly parsed time.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
