### PR TITLE
hotfix/JM-7277 - End trial date can be set before trial start date

### DIFF
--- a/server/config/validation/end-trial.js
+++ b/server/config/validation/end-trial.js
@@ -6,10 +6,10 @@
     , formatRegex = /^([0-9][0-9])(\/)([0-9][0-9])(\/)\d{4}$/
     , charRegex = /[^0-9\/]+/;
 
-  module.exports = () => {
+  module.exports = (trialStartDate) => {
     return {
       endTrialDate: {
-        endTrialDatePicker: {},
+        endTrialDatePicker: {trialStartDate},
       },
       endTrial: {
         presence: {
@@ -51,6 +51,13 @@
         details: 'Enter a real date',
       }];
     };
+
+    if (moment(attributes.endTrialDate, 'DD/MM/YYYY').isBefore(options.trialStartDate)) {
+      return [{
+        summary: 'Trial end date cannot be before start date',
+        details: 'Trial end date cannot be before start date',
+      }];
+    }
 
     return null;
   };

--- a/server/config/validation/end-trial.spec.js
+++ b/server/config/validation/end-trial.spec.js
@@ -2,6 +2,7 @@
 (function() {
     'use strict';
     var validate = require('validate.js')
+      , { makeDate } = require('../../components/filters')
       , validator = require('./end-trial')
       , validatorResult = null;
   
@@ -98,6 +99,23 @@
         expect(validatorResult.endTrialDate[0]).to.have.ownPropertyDescriptor('details');
         expect(validatorResult.endTrialDate[0].summary).to.equal('Enter a real date');
         expect(validatorResult.endTrialDate[0].details).to.equal('Enter a real date');
+  
+      });
+  
+      it('should try to validate an invalid request - Trial end date before start date', function() {
+        const mockRequest = {
+          endTrial: 'true',
+          endTrialDate: '30/05/2024',
+        };
+        const trialStartDate = makeDate(['2024', '05', '31'])
+  
+        validatorResult = validate(mockRequest, validator(trialStartDate));
+  
+        expect(validatorResult).to.be.an('object');
+        expect(validatorResult.endTrialDate[0]).to.have.ownPropertyDescriptor('summary');
+        expect(validatorResult.endTrialDate[0]).to.have.ownPropertyDescriptor('details');
+        expect(validatorResult.endTrialDate[0].summary).to.equal('Trial end date cannot be before start date');
+        expect(validatorResult.endTrialDate[0].details).to.equal('Trial end date cannot be before start date');
   
       });
     });

--- a/server/routes/trial-management/trial-management.controller.js
+++ b/server/routes/trial-management/trial-management.controller.js
@@ -242,19 +242,26 @@
 
   module.exports.postEndTrial = function(app) {
     return async function(req, res) {
-      const validateEndTrialDate = validate(req.body, endTrialDateValidator());
-
-      if (typeof validateEndTrialDate !== 'undefined') {
-        req.session.errors = validateEndTrialDate;
-        req.session.formFields = req.body;
-
-        return res.redirect(app.namedRoutes.build('trial-management.trials.end-trial.get', {
-          trialNumber: req.params.trialNumber,
-          locationCode: req.params.locationCode,
-        }));
-      }
-
       try {
+        const trialDetails = await trialDetailsObject.get(
+          require('request-promise'),
+          app,
+          req.session.authToken,
+          req.params.trialNumber,
+          req.params.locationCode,
+        );
+        const validateEndTrialDate = validate(req.body, endTrialDateValidator(makeDate(trialDetails.start_date)));
+
+        if (typeof validateEndTrialDate !== 'undefined') {
+          req.session.errors = validateEndTrialDate;
+          req.session.formFields = req.body;
+
+          return res.redirect(app.namedRoutes.build('trial-management.trials.end-trial.get', {
+            trialNumber: req.params.trialNumber,
+            locationCode: req.params.locationCode,
+          }));
+        }
+
         if (req.body.endTrial === 'true') {
 
           let payload = {


### PR DESCRIPTION
### JIRA link ###

[JM-7277 - End trial date can be set before trial start date 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7277)

### Description ###

- Added check to see if Trial end date is before start date.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
