### PR TITLE
Non-Bureau users can not reassign jurors

### DIFF
--- a/client/templates/juror-management/_partials/juror-update-options.njk
+++ b/client/templates/juror-management/_partials/juror-update-options.njk
@@ -41,12 +41,12 @@
 
 {# court owned options #}
 {% if jurorStatus === "Summoned" and owner !== "400" %}
-  {% set updateOptions = [responded, deferral, excusal, disqualify, postpone, deceased, undeliverable] %}
+  {% set updateOptions = [responded, deferral, excusal, disqualify, postpone, deceased, undeliverable, reassign] %}
 {% endif %}
 
 {# responded and no attendances #}
 {% if jurorStatus === "Responded" and attendances === 0 and owner !== "400" %}
-  {% set updateOptions = [deferral, excusal, disqualify, postpone, deceased, complete, failedToAttend] %}
+  {% set updateOptions = [deferral, excusal, disqualify, postpone, deceased, complete, failedToAttend, reassign] %}
 {% endif %}
 
 {# responded and attendances #}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7236)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=371)


### Change description ###
Currently the option to reassign Jurors is only possible for Bureau officers when updating a juror record.

!MicrosoftTeams-image.png|width=1341,height=2097,alt="MicrosoftTeams-image.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
