### PR TITLE
When entering draft expenses and clicking save and back an invalid payload is set to the BE code which leads to a 400 being returned

### DIFF
--- a/server/routes/juror-management/expenses/enter-expenses/enter-expenses.controller.js
+++ b/server/routes/juror-management/expenses/enter-expenses/enter-expenses.controller.js
@@ -244,8 +244,6 @@
           'expense_list': [{ ...data }],
         };
 
-        delete payload.expense_list[0];
-
         await postRecalculateSummaryTotalsDAO.post(app, req, locCode, jurorNumber, payload);
       } catch (err) {
         if (err.error && err.error.code === 'EXPENSES_CANNOT_BE_LESS_THAN_ZERO') {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7401)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=401)


### Change description ###
Resolved [org.springframework.web.bind.MethodArgumentNotValidException: Validation failed for argument [2] in public org.springframework.http.ResponseEntity<uk.gov.hmcts.juror.api.moj.controller.request.expense.CombinedExpenseDetailsDto<uk.gov.hmcts.juror.api.moj.controller.response.expense.ExpenseDetailsForTotals>> uk.gov.hmcts.juror.api.moj.controller.JurorExpenseController.calculateTotals(java.lang.String,java.lang.String,uk.gov.hmcts.juror.api.moj.controller.request.expense.CalculateTotalExpenseRequestDto): [Field error in object 'calculateTotalExpenseRequestDto' on field 'expenseList[0]': rejected value [null]; codes [NotNull.calculateTotalExpenseRequestDto.expenseList[0],NotNull.calculateTotalExpenseRequestDto.expenseList,NotNull.expenseList[0],NotNull.expenseList,NotNull]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [calculateTotalExpenseRequestDto.expenseList[0],expenseList[0]]; arguments []; default message [expenseList[0]]]; default message [must not be null]] ] 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
