### PR TITLE
As a jury officer I need to be able to generate a unpaid attendance summary report (FE)

### DIFF
--- a/client/templates/reporting/court-reports.njk
+++ b/client/templates/reporting/court-reports.njk
@@ -22,7 +22,7 @@
         <li><a class="govuk-link" href="{{ url('reports.trial-attendance.filter.get') }}">Trial attendance</a></li>
         <li><a class="govuk-link" href="{{ url('reports.unconfirmed-attendance.filter.get') }}">Unconfirmed attendance</a></li>
         <li><a class="govuk-link" href="#">Unpaid attendance (detailed)</a></li>
-        <li><a class="govuk-link" href="#">Unpaid attendance (summary)</a></li>
+        <li><a class="govuk-link" href="{{ url('reports.unpaid-attendance.filter.get') }}">Unpaid attendance (summary)</a></li>
 
       </ul>
 

--- a/server/config/validation/report-search-by.js
+++ b/server/config/validation/report-search-by.js
@@ -23,6 +23,16 @@
         details: 'Enter a date to search postponed jurors up until',
       }],
     },
+    unpaidAttendance: {
+      dateFrom: [{
+        summary: 'Enter a date to search unpaid attendances from',
+        details: 'Enter a date to search unpaid attendances from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search unpaid attendances up until',
+        details: 'Enter a date to search unpaid attendances up until',
+      }],
+    },
     bulkPrintAudit: {
       dateFrom: [{
         summary: 'Enter a date to search bulk-printing from',

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -962,10 +962,6 @@
           'reportTime',
           '',
           'courtName',
-          'jurorNumber',
-          'firstName',
-          'lastName',
-          'totalUnpaidAttendances',
         ],
         cellTransformer: (data, key, output, isPrint) => {
           const percentageKey = _.camelCase(`${key}_percentage`);

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -1259,6 +1259,32 @@
           sortGroups: 'ascending',
         },
       },
+      'unpaid-attendance': {
+        title: 'Unpaid attendance report (summary)',
+        apiKey: 'UnpaidAttendanceSummaryReport',
+        search: 'dateRange',
+        headings: [
+          'dateFrom',
+          'dateTo',
+          'reportTime',
+          'reportDate',
+          'courtName',
+          'jurorNumber',
+          'firstName',
+          'lastName',
+          'totalUnpaidAttendances',
+        ],
+        grouped: {
+          headings: {
+            transformer: (data, isPrint) => {
+              const [attendanceDate, poolType] = data.split(',');
+              const formattedAttendanceDate = ''; dateFilter(attendanceDate, 'YYYY-mm-dd', 'dddd D MMMM YYYY');
+            },
+          },
+          groupHeader: true,
+          totals: true,
+        }
+      },
     };
   };
 })();

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -962,6 +962,10 @@
           'reportTime',
           '',
           'courtName',
+          'jurorNumber',
+          'firstName',
+          'lastName',
+          'totalUnpaidAttendances',
         ],
         cellTransformer: (data, key, output, isPrint) => {
           const percentageKey = _.camelCase(`${key}_percentage`);

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -1261,21 +1261,15 @@
         search: 'dateRange',
         headings: [
           'dateFrom',
+          'reportDate',
           'dateTo',
           'reportTime',
-          'reportDate',
-          'courtName',
-          'jurorNumber',
-          'firstName',
-          'lastName',
           'totalUnpaidAttendances',
+          'courtName',
         ],
         grouped: {
           headings: {
-            transformer: (data, isPrint) => {
-              const [attendanceDate, poolType] = data.split(',');
-              const formattedAttendanceDate = ''; dateFilter(attendanceDate, 'YYYY-mm-dd', 'dddd D MMMM YYYY');
-            },
+            transformer: (data) => dateFilter(data, 'YYYY-mm-dd', 'dddd D MMMM YYYY'),
           },
           groupHeader: true,
           totals: true,

--- a/server/routes/reporting/standard-report/index.js
+++ b/server/routes/reporting/standard-report/index.js
@@ -87,6 +87,7 @@
     standardReportRoutes(app, 'available-list-pool');
     standardReportRoutes(app, 'available-list-date');
     standardReportRoutes(app, 'payment-status-report');
+    standardReportRoutes(app, 'unpaid-attendance');
   };
 
 })();


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6490)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=443)


### Change description ###
|JMRSM 15:|The system shall enable officers to generate an unpaid attendance summary report|
|Requirement Description|The system shall enable officer to generate an unpaid attendance summary reprort.
 
# The system shall allow the officer to enter the following details:
#* Date from
#** Must be a real date
#* Date to
#** Must be a real date
#** Must be after attendance from
# The system shall allow the officer to continue and show the following values in the header:
#* Date from
#* Date to
#* Total unpaid attendances
#* Report created
#* Time created
#* Court name
# The system shall display the following columns that are separated in to section for each day:
#* Juror number (hyperlink)
#* First name
#* Last name
#* Total (per day)
# The system hall allow the officer to print the report and a PDF
Dev note
The list contain juror with unpaid attendances for that court for the days in the date range|
|Owner|Product Owner|
|Additional Details|*Existing Juror heritage Screens*
[Juror expenditure report (low level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950791225/Juror+expenditure+report+low+level+report]
[Juror expenditure report (high level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950332455/Juror+expenditure+report+high+level+report]
[Attendance Graph - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950037587/Attendance+Graph]
[Generate and view statistics - Incomplete service report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950660146/Generate+and+view+statistics+-+Incomplete+service+report]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate a report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950856733/Generate+a+report]
[Generate a report of jurors due to attend - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950201383/Generate+a+report+of+jurors+due+to+attend]
*Data type for user inputs*
* System generated
* Alphanumeric
* System generated
* Numeric
* Numeric
* Numeric
* Numeric
* System generated
 
*High level requirements*
JRC-HLR-04, JRB-HLR-17, JRB-HLR-18, JRB-HLR-19, JRB-HLR-20, JRB-HLR-21, JRB-HLR-22, JRB-HLR-23, JRB-HLR-24, JRB-HLR-25, JRB-HLR-26, JRC-HLR-12, JRC-HLR-13, JRC-HLR-21, JRC-HLR-33, JRC-HLR-34, JRC-HLR-35, JRC-HLR-36, JRC-HLR-31, JRC-HLR-32
 
*New Screen Design*
[Reports (SPEC) – Figma|https://www.figma.com/file/YvdqYIgmd4q0VLg7Npw9O4/Reports-(SPEC)?type=design&node-id=0-1&mode=design&t=cA1tq98yplBWevF1-0]|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
