### PR TITLE
When search results is limited by APP_SETTING.SEARCH_RESULT_LIMIT_TEAM* setting, message isnt shown indicating that it's a limited results set

### DIFF
--- a/client/templates/search/index.njk
+++ b/client/templates/search/index.njk
@@ -263,31 +263,37 @@
     <div class="govuk-grid-column-full search-content govuk-body">
 
       {% if responses.juror_response %}
-          {% if responses.juror_response.length === 0 %}
-             <div id="noResultsMsg">
-               <h2 class="govuk-heading-m">There are no matching results.</h2>
+        {% if responses.juror_response.length === 0 %}
 
-               <p class="govuk_body">Improve your search by:</p>
-               <ul class="govuk-list govuk-list--bullet">
-                 <li>double-checking your spelling</li>
-                 <li>searching by juror number or juror’s last name or juror’s pool number</li>
-               </ul>
-             </div>
-          {% elif responses.limit_exceeded %}
+          <div id="noResultsMsg">
+            <h2 class="govuk-heading-m">There are no matching results.</h2>
+
+            <p class="govuk_body">Improve your search by:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>double-checking your spelling</li>
+              <li>searching by juror number or juror’s last name or juror’s pool number</li>
+            </ul>
+          </div>
+
+        {% elif responses.limit_exceeded %}
+
           <h2
             id="maxExceeded"
-            class="govuk-heading-m additional-info-text search-loaded">
+            class="govuk-heading-m additional-info-text search-loaded"
+          >
             The specified search resulted in more than <span class="maxRecordsMsg">{{ responses.limit }}</span> results. This list only shows the oldest <span class="maxRecordsMsg">{{ responses.limit }}</span>.
           </h2>
 
-          {% else %}
+        {% else %}
+
           <h2
             id="searchSummaryMsg"
             class="govuk-heading-m"
           >
             <span id="resultCount">{{ responses.juror_response.length }}</span> results for <span id="resultsStr">{{ resultsStr | safe }}</span>
           </h2>
-          {% endif %}
+
+        {% endif %}
       {% endif %}
 
       <form

--- a/client/templates/search/index.njk
+++ b/client/templates/search/index.njk
@@ -262,28 +262,33 @@
 
     <div class="govuk-grid-column-full search-content govuk-body">
 
-      <h2
-        id="searchSummaryMsg"
-        class="govuk-heading-m {% if not responses.juror_response or responses.juror_response.length === 0 %} u-hide{% endif %}"
-      >
-        <span id="resultCount">{{ responses.juror_response.length }}</span> results for <span id="resultsStr">{{ resultsStr | safe }}</span>
-      </h2>
+      {% if responses.juror_response %}
+          {% if responses.juror_response.length === 0 %}
+             <div id="noResultsMsg">
+               <h2 class="govuk-heading-m">There are no matching results.</h2>
 
-      {# <h2
-        id="maxExceeded"
-        class="govuk-heading-m additional-info-text {% if not results %} u-hide{% elif meta.total <= meta.max %} u-hide{% endif %} search-loaded">
-        The specified search resulted in more than <span class="maxRecordsMsg">{{ meta.max }}</span> results. This list only shows the oldest <span class="maxRecordsMsg">{{ meta.max }}</span>.
-      </h2> #}
+               <p class="govuk_body">Improve your search by:</p>
+               <ul class="govuk-list govuk-list--bullet">
+                 <li>double-checking your spelling</li>
+                 <li>searching by juror number or juror’s last name or juror’s pool number</li>
+               </ul>
+             </div>
+          {% elif responses.limit_exceeded %}
+          <h2
+            id="maxExceeded"
+            class="govuk-heading-m additional-info-text search-loaded">
+            The specified search resulted in more than <span class="maxRecordsMsg">{{ responses.limit }}</span> results. This list only shows the oldest <span class="maxRecordsMsg">{{ responses.limit }}</span>.
+          </h2>
 
-      <div id="noResultsMsg" class="{% if not responses.juror_response or responses.juror_response.length > 0 %} u-hide{% endif %}">
-        <h2 class="govuk-heading-m">There are no matching results.</h2>
-
-        <p class="govuk_body">Improve your search by:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>double-checking your spelling</li>
-          <li>searching by juror number or juror’s last name or juror’s pool number</li>
-        </ul>
-      </div>
+          {% else %}
+          <h2
+            id="searchSummaryMsg"
+            class="govuk-heading-m"
+          >
+            <span id="resultCount">{{ responses.juror_response.length }}</span> results for <span id="resultsStr">{{ resultsStr | safe }}</span>
+          </h2>
+          {% endif %}
+      {% endif %}
 
       <form
         class="govuk-form-group {% if errors.items['selectedResponses']%}govuk-form-group--error{% endif %}"


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7409)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=456)


### Change description ###
Previously, when a search result was limited because the APP_SETTING.SEARCH_RESULT_LIMIT_TEAM_LEADER or APP_SETTING.SEARCH_RESULT_LIMIT_BUREAU_OFFICER was set and the results set exceeded that, the user saw the results set and this message, so it was clear that the results set was limited:

{{And I see "The specified search resulted in more than 100 results. This list only shows the oldest 100." on the page}}

Now this message is not displayed to the user, and it appears that the complete results set is shown (there are >100 rows when I increase the setting)

!image-20240524-101000.png|width=1229,height=698,alt="image-20240524-101000.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
