### PR TITLE
As a Court officer I want to generate a Completion of service report (FE)

### DIFF
--- a/client/templates/reporting/court-reports.njk
+++ b/client/templates/reporting/court-reports.njk
@@ -30,7 +30,7 @@
       <ul class="govuk-list">
         <li><a class="govuk-link" href="{{ url('reports.available-list.filter.get') }}">Available list</a></li>
         <li><a class="govuk-link" href="{{ url('reports.current-pool-status.filter.get') }}">Current pool status report</a></li>
-        <li><a class="govuk-link" href="#">Completion of service report</a></li>
+        <li><a class="govuk-link" href="{{ url('reports.completion-of-service.filter.get') }}">Completion of service report</a></li>
         <li><a class="govuk-link" href="{{ url('reports.deferred-list.filter.get') }}">Deferred list</a></li>
         <li><a class="govuk-link" href="{{ url('reports.excused-disqualified.filter.get') }}">Excused and disqualified list</a></li>
         <li><a class="govuk-link" href="{{ url('reports.next-due.filter.get') }}">Next attendance date report</a> (previously Summary)</li>

--- a/client/templates/reporting/standard-reports/date-search/fixed-range.njk
+++ b/client/templates/reporting/standard-reports/date-search/fixed-range.njk
@@ -1,9 +1,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set dateRangeHtml %}
-  {% set dateFromLabel = "Service start date from" %}
-  {% set dateToLabel = "Service start date to" %}
-
   {% include "./from-to.njk" %}
 {% endset %}
 
@@ -16,7 +13,8 @@
     }
   },
   items: [
-    { value: "NEXT_31_DAYS", text: "Next 31 days" },
+    { value: "NEXT_31_DAYS", text: "Next 31 days" } if "NEXT_31_DAYS" in fixedDateRangeValues,
+    { value: "LAST_31_DAYS", text: "Last 31 days" } if "LAST_31_DAYS" in fixedDateRangeValues,
     {
       value: "CUSTOM_RANGE",
       text: "Custom date range",
@@ -24,6 +22,6 @@
         html: dateRangeHtml
       },
       checked: errors.count > 0
-    }
+    } if "CUSTOM_RANGE" in fixedDateRangeValues
   ]
 }) }}

--- a/client/templates/reporting/standard-reports/date-search/from-to.njk
+++ b/client/templates/reporting/standard-reports/date-search/from-to.njk
@@ -1,7 +1,7 @@
 {{ datePicker({
   id: "dateFrom",
   label: {
-    text: dateFromLabel or searchLabels.dateFrom or "Date from"
+    text: searchLabels.dateFrom or "Date from"
   },
   hint: "Use dd/mm/yyyy format.",
   dateValue: tmpBody.dateFrom,
@@ -11,7 +11,7 @@
 {{ datePicker({
   id: "dateTo",
   label: {
-    text: dateToLabel or searchLabels.dateTo or "Date to"
+    text: searchLabels.dateTo or "Date to"
   },
   hint: "Use dd/mm/yyyy format.",
   dateMin: tmpBody.dateFrom,

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -22,6 +22,7 @@
   //     dateFrom: string, // custom label for date from input 
   //     dateTo: string, // custom label for date to input 
   //   },
+  //   fixedDateRangeValues?: [string]  // list of values to be used in fixed date range,
   //   queryParams?: { // any mandatory query params neederd throughout report journey 
   //     key: value,
   //   },
@@ -306,6 +307,11 @@
         title: 'Reasonable adjustments report',
         apiKey: 'ReasonableAdjustmentsReport',
         search: 'fixedDateRange',
+        searchLabelMappers: {
+          dateFrom: 'Service start date from',
+          dateTo: 'Service start date from',
+        },
+        fixedDateRangeValues: ['NEXT_31_DAYS', 'CUSTOM_RANGE'],
         headings: [
           'totalReasonableAdjustments',
           'reportDate',
@@ -1523,6 +1529,40 @@
           'serviceStartDate',
           'courtName',
         ],
+      },
+      'completion-of-service': {
+        title: 'Completion of service report',
+        apiKey: 'CompletionOfServiceReport',
+        search: 'fixedDateRange',
+        fixedDateRangeValues: ['LAST_31_DAYS', 'CUSTOM_RANGE'],
+        headings: [
+          'dateFrom',
+          'reportDate',
+          'dateTo',
+          'reportTime',
+          'totalPoolMembersCompleted',
+          'courtName'
+        ],
+        grouped: {
+          headings: {
+            transformer: (data, isPrint) => {
+              const [poolNumber, poolType] = data.split(',');
+              if (isPrint) {
+                return [
+                  `Pool ${poolNumber} `,
+                  {
+                    text: capitalizeFully(poolType),
+                    color: '#505A5F',
+                    fontSize: 10,
+                    bold: false
+                  }];
+              }
+              return `${makeLink(app)['poolNumber'](poolNumber)} <span class="grouped-display-inline">${capitalizeFully(poolType)}</span>`;
+            },
+          },
+          totals: true,
+          groupHeader: true,
+        },
       },
     };
   };

--- a/server/routes/reporting/standard-report/index.js
+++ b/server/routes/reporting/standard-report/index.js
@@ -106,6 +106,7 @@
     standardReportRoutes(app, 'pool-ratio');
     standardReportRoutes(app, 'pool-attendance-audit');
     standardReportRoutes(app, 'pool-selection');
+    standardReportRoutes(app, 'completion-of-service');
   };
 
 })();

--- a/server/routes/reporting/standard-report/standard-report.controller.js
+++ b/server/routes/reporting/standard-report/standard-report.controller.js
@@ -176,6 +176,7 @@
             items: tmpErrors,
           },
           isFixedDateRange,
+          fixedDateRangeValues: reportType.fixedDateRangeValues || [],
           tmpBody,
           reportKey,
           customSearchLabel,
@@ -672,6 +673,10 @@
       if (req.body.dateRange && req.body.dateRange === 'NEXT_31_DAYS') {
         req.body.dateFrom = moment().format('DD/MM/YYYY');
         req.body.dateTo = moment().add(31, 'days').format('DD/MM/YYYY');
+      }
+      if (req.body.dateRange && req.body.dateRange === 'LAST_31_DAYS') {
+        req.body.dateFrom = moment().subtract(31, 'days').format('DD/MM/YYYY');
+        req.body.dateTo = moment().format('DD/MM/YYYY');
       }
 
       const validatorResult = validate(req.body, searchValidator.dateRange(_.camelCase(reportKey), req.body));


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7325)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=477)


### Change description ###
*Acceptance Criteria*

# *Initiating Report by date:* The system shall prompt the Court officer to select the following date options:
#* Last 31 days
#* Custom date range
#** Date from (date picker) (Can’t be a date in the future)
#** Date to (date picker) (Can’t be a date in the future)
# *Report Generation:* Upon date validation, the system should generate a report detailing the juror in the pool in a summoned or responded juror status.
#* Back (Hyperlink)
#* *Completion of service report* (Header)
#* Print (Tab)
#* Date from
#* Date to
#* Total pool members completed
#* Report created
#* Time created
#* Court name
#* Juror number
#* First name
#* Last name
#* Completion date
# The juror shall be linked by the pools they are in
# The system shall allow the officer to print the report as a PDF

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
