### PR TITLE
hotfix/fix-report-sorting: Update report sorting

### DIFF
--- a/server/routes/reporting/standard-report/standard-report.controller.js
+++ b/server/routes/reporting/standard-report/standard-report.controller.js
@@ -375,10 +375,14 @@
             output = reportType.cellTransformer(data, header.id, output);
           }
 
+          const numericTypes = ['Integer', 'BigDecimal', 'Long', 'Double']
+
           return ({
             html: output ? output : '-',
             attributes: {
-              "data-sort-value": header.dataType === 'LocalDate' ? data[snakeToCamel(header.id)] : output
+              "data-sort-value": output && output !== '-' 
+                ? (header.dataType === 'LocalDate' ? data[snakeToCamel(header.id)] : output) 
+                : (numericTypes.includes(header.dataType) ? '0' : '-')
             },
             format: header.dataType === 'BigDecimal' ? 'numeric' : '',
           });


### PR DESCRIPTION
### Change description ###

Updated report sorting to handle blank entries better for numeric fields.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
