### PR TITLE
Excused and Disqualified report - no error message when no pool is entered

### DIFF
--- a/server/routes/reporting/standard-report/standard-report.controller.js
+++ b/server/routes/reporting/standard-report/standard-report.controller.js
@@ -43,14 +43,18 @@
 
         delete req.session.errors;
 
-        if (filter) {
-          errors = {...validate({poolNumber: filter}, {poolNumber: {poolNumberSearched: {}}})};
+        if (typeof filter !== 'undefined') {
+          if (filter === '') {
+            errors = makeManualError('poolNumber', 'Enter a pool number');
+          } else {
+            errors = {...validate({poolNumber: filter}, {poolNumber: {poolNumberSearched: {}}})};
 
-          if (Object.keys(errors).length === 0) {
-            const api = await poolSearchObject.post(rp, app, req.session.authToken, { poolNumber: filter });
+            if (Object.keys(errors).length === 0) {
+              const api = await poolSearchObject.post(rp, app, req.session.authToken, { poolNumber: filter });
 
-            poolList = api.poolRequests;
-            resultsCount = api.resultsCount;
+              poolList = api.poolRequests;
+              resultsCount = api.resultsCount;
+            }
           }
         }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7513)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
An error message is expected when no pool number is entered on the Excused and Disqualified report.

!Screenshot 2024-06-08 at 13.19.54.png|width=556,height=378,alt="Screenshot 2024-06-08 at 13.19.54.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
