### PR TITLE
Financial Audit reports date range is incorrect.

### DIFF
--- a/server/lib/reports/financial-audit.js
+++ b/server/lib/reports/financial-audit.js
@@ -436,14 +436,14 @@
   const render = (auditData) => {
     const days = auditData.expenses.expenseDetails;
     const dateFrom = days.reduce((prev, curr) => {
-      if (moment(curr.attendanceDate).isBefore(moment(prev?.attendanceDate))) {
+      if (!prev.attendanceDate || moment(curr.attendanceDate).isBefore(moment(prev?.attendanceDate))) {
         return curr;
       }
 
       return prev;
     }, []);
     const dateTo = days.reduce((prev, curr) => {
-      if (moment(curr.attendanceDate).isAfter(moment(prev?.attendanceDate))) {
+      if (!prev.attendanceDate || moment(curr.attendanceDate).isAfter(moment(prev?.attendanceDate))) {
         return curr;
       }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7504)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=497)


### Change description ###
 Financial Audit reports date range is incorrect.
Should show smallest to largest dates that are being approve instead of smallest date to date submitted/approved.

In this example it should be Wednesday 15 May 2024 to Wednesday 15 May 2024

Instead of Wednesday 15 May 2024 to Friday 07 June 2024

!image-20240607-104221.png|width=1138,height=563,alt="image-20240607-104221.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
