### PR TITLE
Pool Attendances Report - button to open report doesn't appear

### DIFF
--- a/client/templates/juror-management/attendance.njk
+++ b/client/templates/juror-management/attendance.njk
@@ -72,7 +72,7 @@
               }
             }) }}
 
-            {% if attendanceStatus === "Unconfirmed" %}
+            {% if attendanceStatus === "Confirmed" %}
               {% set auditNumbers = [] %}
               {% for auditNumber in poolAttendaceAuditNumbers %}
                 {% set auditNumbers = (auditNumbers.push(


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7516)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=501)


### Change description ###
When jurors are in waiting, upon clicking the print attendance audit dropdown there should be a option for a Pool Attendance audit number which will open a report. At the moment this doesn’t occur. Attempted with both confirmed and unconfirmed attendance and still same result.

Only difference is when the attendance is confirmed the print attendance audit dropdown disappears. See screenshots.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
