### PR TITLE
hotfix/JM-6969b - Mark as absent doesn't work from record attendance (hidden absent table)

### DIFF
--- a/client/templates/juror-management/attendance.njk
+++ b/client/templates/juror-management/attendance.njk
@@ -72,7 +72,7 @@
               }
             }) }}
 
-            {% if attendanceStatus === "Unconfirmed" %}
+            {% if attendanceStatus === "Confirmed" %}
               {% set auditNumbers = [] %}
               {% for auditNumber in poolAttendaceAuditNumbers %}
                 {% set auditNumbers = (auditNumbers.push(

--- a/client/templates/juror-management/attendance/confirmed/confirmed.njk
+++ b/client/templates/juror-management/attendance/confirmed/confirmed.njk
@@ -30,7 +30,7 @@
     <div class="govuk-grid-column-full govuk-body">
       
       <b>
-        <span id="confirmedJurors">{{ confirmedJurors.length }}</span> jurors confirmed as attending
+        <span id="confirmedJurors">{{ confirmedJurors.length }}</span> juror{% if confirmedJurors.length > 1 %}s{% endif %} confirmed as attending
       </b>
       
       <table class="govuk-table {% if listedJurors.length === 0 %}js-hidden{% endif %}"
@@ -92,10 +92,10 @@
     <div class="govuk-grid-column-full govuk-body">
 
       <b>
-        <span id="absentJurors">{{ absentJurors.length }}</span> jurors confirmed as absent
+        <span id="absentJurors">{{ absentJurors.length }}</span> juror{% if listedJurors.length > 1 %}s{% endif %} confirmed as absent
       </b>
 
-      <table class="govuk-table {% if listedJurors.length === 0 %}js-hidden{% endif %}"
+      <table class="govuk-table {% if absentJurors.length === 0 %}js-hidden{% endif %}"
       data-module="moj-sortable-table" id="attendanceTable">
         <caption class="govuk-table__caption govuk-visually-hidden">Absent jurors list</caption>
 

--- a/client/templates/juror-management/attendance/confirmed/confirmed.njk
+++ b/client/templates/juror-management/attendance/confirmed/confirmed.njk
@@ -92,7 +92,7 @@
     <div class="govuk-grid-column-full govuk-body">
 
       <b>
-        <span id="absentJurors">{{ absentJurors.length }}</span> juror{% if listedJurors.length > 1 %}s{% endif %} confirmed as absent
+        <span id="absentJurors">{{ absentJurors.length }}</span> juror{% if absentJurors.length > 1 %}s{% endif %} confirmed as absent
       </b>
 
       <table class="govuk-table {% if absentJurors.length === 0 %}js-hidden{% endif %}"


### PR DESCRIPTION
### JIRA link ###

[JM-6969 - Mark as absent doesn't work from record attendance (hidden absent table) 🔗 ](https://centralgovernmentcgi.atlassian.net/browse/JM-6969)

### Description ###

- Fixed wrongly hidden absent table.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
