### PR TITLE
Error message when reassigning a juror but not selecting a pool appear to be incorrect

### DIFF
--- a/server/config/validation/pool-management.js
+++ b/server/config/validation/pool-management.js
@@ -21,8 +21,8 @@
           presence: {
             allowEmpty: false,
             message: {
-              summary: 'Choose a pool to reassign to',
-              details: 'Choose a pool to reassign to',
+              summary: 'Choose an active pool to add selected jurors to',
+              details: 'Choose an active pool to add selected jurors to',
             },
           },
         },


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7473)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=504)


### Change description ###
Message is ‘Choose a pool to reassign to’

But should be ‘Choose an active pool to add selected jurors to’

!image-20240604-110914.png|width=923,height=464,alt="image-20240604-110914.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
