### PR TITLE
hotfix/JM-7491 - Request a DOB when entering a paper summons reply

### DIFF
--- a/server/config/validation/date-picker.js
+++ b/server/config/validation/date-picker.js
@@ -107,7 +107,7 @@
       dateInitial = validateDateInitial(value),
       tmpErrors = [];
 
-    if (!moment(dateInitial.dateAsDate).isBefore(currentDate, 'day')) {
+    if (value !== '' && !moment(dateInitial.dateAsDate).isBefore(currentDate, 'day')) {
       tmpErrors = [{
         summary: 'Date of birth must be in the past',
         details: 'Date of birth must be in the past',

--- a/server/config/validation/paper-reply.js
+++ b/server/config/validation/paper-reply.js
@@ -223,13 +223,6 @@
         },
       },
       dateOfBirth: {
-        presence: {
-          allowEmpty: false,
-          message: {
-            summary: 'Date of birth cannot be empty',
-            details: 'Date of birth cannot be empty',
-          },
-        },
         genericDatePicker: {},
         dateOfBirthDatePicker: {},
       },

--- a/server/objects/paper-reply.js
+++ b/server/objects/paper-reply.js
@@ -34,7 +34,7 @@
             'cjsEmployment': pr.cjsEmployment,
             // this is a weird one that happens on the test environemtn... dates do not convert properly
             // ... this should fix for now but moving to an ISO standard should fix the bigger issue of dates
-            'dateOfBirth': pr.dateOfBirth.split('/').map(num => num.padStart(2, '0')).reverse().join('-'),
+            'dateOfBirth': pr.dateOfBirth !== '' ? pr.dateOfBirth.split('/').map(num => num.padStart(2, '0')).reverse().join('-') : null,
             'deferral': pr.deferral,
             'eligibility': pr.eligibility,
             'emailAddress': pr.emailAddress,

--- a/server/routes/summons-management/update/juror-details.controller.js
+++ b/server/routes/summons-management/update/juror-details.controller.js
@@ -324,7 +324,7 @@
         replyMethod: req.params['type'].toUpperCase(),
       };
 
-      payload.dateOfBirth = dateFilter(req.body.dateOfBirth, 'DD/MM/YYYY', 'YYYY-MM-DD');
+      payload.dateOfBirth = req.body.dateOfBirth !== '' ? dateFilter(req.body.dateOfBirth, 'DD/MM/YYYY', 'YYYY-MM-DD') : null;
       payload.emailAddress = req.body.emailAddress || null;
       payload.primaryPhone = req.body.primaryPhone || null;
       payload.secondaryPhone = req.body.secondaryPhone || null;


### PR DESCRIPTION
### JIRA link ###

[JM-7491 - Request a DOB when entering a paper summons reply 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7491)

### Description ###

- Making DOB not mandatory when entering paper summons reply
- Made DOB null if the string is empty

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
