### PR TITLE
hotfix/JM-7154b - UAT - Jurors not visible when adding more jurors to panel after empanelment (show 'Panel' jurors only)

### DIFF
--- a/server/routes/trial-management/empanel-jury/empanel-jury.controller.js
+++ b/server/routes/trial-management/empanel-jury/empanel-jury.controller.js
@@ -101,7 +101,7 @@
   module.exports.getEmpanelJurors = function(app) {
     return function(req, res) {
       const requiredNumberOfJurors = req.session.trial.requiredNumberOfJurors;
-      const availableJurors = req.session.trial.panelledJurors;
+      const availableJurors = req.session.trial.panelledJurors.filter((juror) => juror.juror_status === 'Panel');
       let tmpErrors = _.clone(req.session.empanelJuryError);
       let tmpBody = _.clone(req.session.formFields);
 


### PR DESCRIPTION
### JIRA link ###

[JM-7154 UAT - Jurors not visible when adding more jurors to panel after empanelment (show 'Panel' jurors only) 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7154)

### Description ###

- Filtered jurors with 'Panel' status only.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
