### PR TITLE
hotfix/JM-7295 - Pool request subheading appearing on Active Pools screen

### DIFF
--- a/client/templates/administration/users/court-bureau-users.njk
+++ b/client/templates/administration/users/court-bureau-users.njk
@@ -58,7 +58,7 @@
         {{ modSortableTable({
           id: "usersTable",
           caption: "Users",
-          captionClass: "govuk-visually-hidden",
+          captionClasses: "govuk-visually-hidden",
           head: users.head,
           rows: users.rows,
           url: '?isActive=' + isActive

--- a/client/templates/administration/users/users.njk
+++ b/client/templates/administration/users/users.njk
@@ -140,7 +140,7 @@
         {{ modSortableTable({
           id: "usersTable",
           caption: "Users",
-          captionClass: "govuk-visually-hidden",
+          captionClasses: "govuk-visually-hidden",
           head: users.head,
           rows: users.rows,
           url: sortUrlPrefix

--- a/client/templates/custom-components/sortable-table/template.njk
+++ b/client/templates/custom-components/sortable-table/template.njk
@@ -54,7 +54,7 @@
     id: params.id
   },
   caption: params.caption,
-  captionClass: params.captionClass,
+  captionClasses: params.captionClasses,
   head: headList,
   rows: params.rows,
   classes: params.classes

--- a/client/templates/juror-management/unpaid-attendance.njk
+++ b/client/templates/juror-management/unpaid-attendance.njk
@@ -94,7 +94,7 @@
         {{ modSortableTable({
           id: "unpaidAttendanceTable",
           caption: "Unpaid attendance",
-          captionClass: "govuk-visually-hidden",
+          captionClasses: "govuk-visually-hidden",
           head: unpaidAttendanceList.head,
           rows: unpaidAttendanceList.rows,
           url: urlPrefix

--- a/client/templates/messaging/_partials/jurors-table.njk
+++ b/client/templates/messaging/_partials/jurors-table.njk
@@ -136,7 +136,7 @@
   {{ modSortableTable({
     id: "messageJurorsTable",
     caption: "Jurors",
-    captionClass: "govuk-visually-hidden",
+    captionClasses: "govuk-visually-hidden",
     classes: "mod-horizontal-scroll-table",
     head: [
       {

--- a/client/templates/messaging/_partials/trials-table.njk
+++ b/client/templates/messaging/_partials/trials-table.njk
@@ -7,7 +7,7 @@
     {{ modSortableTable({
       id: "trialsTable",
       caption: "Trials",
-      captionClass: "govuk-visually-hidden",
+      captionClasses: "govuk-visually-hidden",
       head: trials.head,
       rows: trials.rows,
       url: urlPrefix

--- a/client/templates/pool-management/coroner-court/_partials/results-table.njk
+++ b/client/templates/pool-management/coroner-court/_partials/results-table.njk
@@ -44,7 +44,7 @@
 {{ modSortableTable({
   id: "coronerPoolsTable",
   caption: "Coroner court pools",
-  captionClass: "govuk-visually-hidden",
+  captionClasses: "govuk-visually-hidden",
   head: headings,
   rows: rows,
   url: urlPrefix

--- a/client/templates/pool-management/index.njk
+++ b/client/templates/pool-management/index.njk
@@ -117,7 +117,7 @@
     {{ modSortableTable({
       id: "poolRequestsTable",
       caption: "Pool requests",
-      captionClass: "govuk-visually-hidden",
+      captionClasses: "govuk-visually-hidden",
       head: poolList.head,
       rows: poolList.rows,
       url: urlPrefix

--- a/client/templates/pool-management/pool-overview/bureau-pool-jurors.njk
+++ b/client/templates/pool-management/pool-overview/bureau-pool-jurors.njk
@@ -132,7 +132,7 @@
           {{ modSortableTable({
             id: "jurorOverview",
             caption: "Jurors in pool",
-            captionClass: "govuk-visually-hidden",
+            captionClasses: "govuk-visually-hidden",
             head: membersHeaders,
             rows: poolMembers,
             url: urlPrefix

--- a/client/templates/pool-management/pool-overview/court-pool-jurors.njk
+++ b/client/templates/pool-management/pool-overview/court-pool-jurors.njk
@@ -95,7 +95,7 @@
         {{ modSortableTable({
           id: "jurorOverview",
           caption: "Jurors in pool",
-          captionClass: "govuk-visually-hidden",
+          captionClasses: "govuk-visually-hidden",
           head: membersHeaders,
           rows: poolMembers,
           url: sortUrl

--- a/client/templates/sjo-tasks/uncomplete-service/select-jurors.njk
+++ b/client/templates/sjo-tasks/uncomplete-service/select-jurors.njk
@@ -67,7 +67,7 @@
         {{ modSortableTable({
               id: "completedJurorsTable",
               caption: "Jurors",
-              captionClass: "govuk-visually-hidden",
+              captionClasses: "govuk-visually-hidden",
               head: completedJurorsList.head,
               rows: completedJurorsList.rows,
               url: urlPrefix,

--- a/client/templates/trial-management/trials.njk
+++ b/client/templates/trial-management/trials.njk
@@ -81,7 +81,7 @@
         {{ modSortableTable({
           id: "trialsTable",
           caption: "Trials",
-          captionClass: "govuk-visually-hidden",
+          captionClasses: "govuk-visually-hidden",
           head: trials.head,
           rows: trials.rows,
           url: urlPrefix


### PR DESCRIPTION
### JIRA link ###

[JM-7295 - Pool request subheading appearing on Active Pools screen 🔗](https://centralgovernmentcgi.atlassian.net/browse/JM-7295)

### Description ###

- Fixed hidden class for table captions.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
