### PR TITLE
Juror amendment incorrectly named

### DIFF
--- a/client/templates/reporting/court-reports.njk
+++ b/client/templates/reporting/court-reports.njk
@@ -45,7 +45,7 @@
       {% if isSJO %}
         <h2 class="govuk-heading-m">Senior jury officer reports</h2>
         <ul class="govuk-list">
-          <li><a class="govuk-link" href="{{ url('reports.juror-amendment.search.get') }}">Juror ammendment report</a></li>
+          <li><a class="govuk-link" href="{{ url('reports.juror-amendment.search.get') }}">Juror amendment report</a></li>
           <li><a class="govuk-link" href="{{ url('reports.manual-juror-report.filter.get') }}">Manually-created jurors report</a></li>
         </ul>
       {% endif %}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7509)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=522)


### Change description ###
* Jury not Juror
* ammendment not amendment

!image-20240607-152453.png|width=365,height=136,alt="image-20240607-152453.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
