### PR TITLE
Juror history not display trial number or attendance date for trials on trial history events

### DIFF
--- a/client/templates/juror-management/_partials/history-tab.njk
+++ b/client/templates/juror-management/_partials/history-tab.njk
@@ -13,9 +13,9 @@
     {% endset %}
     
     {% set historyHtml %}
-      <div class='entry'>{{historyItem.otherInfoDate | historyAttendanceDate}}</div>
-      <div class='entry'>{{historyItem.otherInfoRef | historyAuditLinkify | safe}}</div>
-      <div class='entry'>{{historyItem.otherInfo | historyAuditLinkify | safe}}</div>
+      {% for historyDetails in historyItem.historyDetails %}
+        <div class='entry'>{{historyDetails | historyAuditLinkify | safe}}</div>
+      {% endfor %}
     {% endset %}
 
     {% set historyTimeline = (historyTimeline.push({


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7562)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=553)


### Change description ###
When pulling through history for a trail the history is not including the trial number or the attendance date for the trial which is should

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
