### PR TITLE
Bug (JM-7547) fix missing enter summons buttons

### DIFF
--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -344,6 +344,7 @@
                 juror: jurorOverview.data,
                 jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
                 currentTab: 'expenses',
+                canSummon: canSummon(req, jurorOverview.data.commonDetails),
                 hasSummons: jurorOverview.data.commonDetails.hasSummonsResponse,
                 dailyExpenses,
                 defaultExpenses,
@@ -1050,6 +1051,8 @@
         juror,
         historyUrl: app.namedRoutes.build('juror-record.history.get', { jurorNumber }),
         historyTab,
+        canSummon: canSummon(req, juror.commonDetails),
+        hasSummons: juror.commonDetails.hasSummonsResponse,
         history,
         currentTab: 'history',
         backLinkUrl: {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7547

### Change description ###

Fix missing 'enter summons' button on expenses and history tabs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
