### PR TITLE
When summoning extra jurors "Jurors required to complete the request" shows a negative number if we summon over the required quantity

### DIFF
--- a/client/templates/pool-management/additional-summons/index.njk
+++ b/client/templates/pool-management/additional-summons/index.njk
@@ -8,6 +8,9 @@
 
 {% set currentApp = "Pool management" %}
 
+{% block page_title %}{{ serviceName }} - Pool overview - Summon additional jurors{% endblock %}
+{% block page_identifier %}Pool overview - Summon additional jurors{% endblock %}
+
 {% block content%}
 
   {% include "includes/errors.njk" %}

--- a/client/templates/pool-management/additional-summons/index.njk
+++ b/client/templates/pool-management/additional-summons/index.njk
@@ -59,7 +59,8 @@
 
         <p class="govuk-body">
           <span class="govuk-heading-s">Jurors required to complete the request</span>
-          {{ poolDetails.bureauSummoning.required - poolDetails.bureauSummoning.confirmed }}
+          {% set jurorsRequiredToCompleteRequest = poolDetails.bureauSummoning.required - poolDetails.bureauSummoning.confirmed %}
+          {{ jurorsRequiredToCompleteRequest if jurorsRequiredToCompleteRequest > 0 else "0" }}
         </p>
 
         <p class="govuk-body">


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7599)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=557)


### Change description ###
When we summon voters on a pool that has more jurors than required, the form will show a negative number for how many jurors is left on the required amount.

We should just probably display 0.

!image-20240619-142612.png|width=462,height=115,alt="image-20240619-142612.png"!

And this page does not have a title.

h3. Info

Having a total confirmed larger than required on the pool would cause the required number left to be negative.

!image-20240620-083206.png|width=339,height=249,alt="image-20240620-083206.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
