### PR TITLE
UAT - It shows the wrong time and message in pool history when editing the pool and adding a comment

### DIFF
--- a/client/templates/pool-management/pool-overview/pool-history.njk
+++ b/client/templates/pool-management/pool-overview/pool-history.njk
@@ -9,7 +9,9 @@
     {% set historyHtml = undefined %}
     {% for historyLog in poolHistory %}
       {% set historyHtml %}
-      <p class="govuk-body">{{ historyLog.otherInformation }}</p>
+      {% for historyDetails in historyLog.otherInformation.split('\n') %}
+        <p class="govuk-body">{{ historyDetails }}</p>
+      {% endfor %}
       {% endset %}
       {% set logs = (logs.push({
         label: {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7180)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=563)


### Change description ###
It shows the wrong time and message in pool history when adding a comment to a pool edit



!image-20240430-150013.png|width=451,height=276,alt="image-20240430-150013.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
