### PR TITLE
Bug (JM-6711) juror details edit screen now updates welsh flag

### DIFF
--- a/client/templates/juror-management/edit/juror-edit-details.njk
+++ b/client/templates/juror-management/edit/juror-edit-details.njk
@@ -354,7 +354,7 @@
               {
                 value: "true",
                 text: "Yes, send Welsh language communications",
-                checked: details.welsh
+                checked: juror.welsh
               }
             ]
           }) }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7611

### Change description ###

Juror details edit screen wasn't reading the current value of the Welsh flag - this has been fixed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
