### PR TITLE
Fix (JM-7614) force parsing of dates in Europe/London

### DIFF
--- a/server/components/filters/index.js
+++ b/server/components/filters/index.js
@@ -132,7 +132,7 @@
 
       Array.prototype.push.apply(args, arguments);
       try {
-        mnt = moment(date, inputFormat);
+        mnt = moment(date, inputFormat).utcOffset("Europe/London");
       } catch (err) {
         errs.push(err);
       }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7614

### Change description ###

Because the FE server (probably) runs in UTC, force parsing dates from Europe/London for timezone purposes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
