### PR TITLE
Bug (JM-7660) fix missing status on history tab

### DIFF
--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1063,6 +1063,7 @@
         court: isCourtUser(req, res),
         jurorNumber,
         juror,
+        jurorStatus: resolveJurorStatus(juror.commonDetails),
         historyUrl: app.namedRoutes.build('juror-record.history.get', { jurorNumber }),
         historyTab,
         canSummon: canSummon(req, juror.commonDetails),


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7660

### Change description ###

Fixes missing juror status on the history tab of the juror record

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
