### PR TITLE
Bug (JM-7669) fix missing jurorNumber on export contact details

### DIFF
--- a/client/js/export-contact-details.js
+++ b/client/js/export-contact-details.js
@@ -101,7 +101,7 @@
     return $.ajax({
       url: '/messaging/export-contact-details/jurors/check?action='
         + action + (queryParams ? queryParams : '&poolNumber=' + poolNumber)
-        + (!isSearchByJurorNumber ? '&jurorNumber=' + jurorNumber : ''),
+        + '&jurorNumber=' + jurorNumber,
       method: 'POST',
       data: {
         _csrf: csrfToken.val(),

--- a/server/objects/messaging.js
+++ b/server/objects/messaging.js
@@ -125,7 +125,7 @@
         headers: {
           Authorization: req.session.authToken,
           'Content-Type': 'application/json',
-          'Accept': 'text/csv',
+          'Accept': 'text/csv, application/json',
         },
         json: true,
         body,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7669

### Change description ###

The ajax endpoint wasn't adding juror number to the stored data if we had searched by juror number, which meant sending undefined to the server. This fixes that, and also accepts application/json from the csv endpoint as well as csv so we can actually receive error messages if this happens again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
