### PR TITLE
Bug (JM-7682) fix looking up jurors by auth code instead of loccode

### DIFF
--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -28,7 +28,7 @@
           require('request-promise'),
           app,
           req.session.authToken,
-          req.session.authentication.owner,
+          req.session.authentication.locCode,
           selectedDateString,
           group
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###

Found on https://centralgovernmentcgi.atlassian.net/browse/JM-7682

### Change description ###

Update the confirm attendance screen to get attendance by locCode of current locCode, rather than by locCode of current auth code, which meant satellites were always seeing their primary instead of local jurors.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
