### PR TITLE
Messaging juror hyperlink not always working says juror not found

### DIFF
--- a/client/templates/messaging/_common/juror-record-url.macro.njk
+++ b/client/templates/messaging/_common/juror-record-url.macro.njk
@@ -1,0 +1,5 @@
+{% macro jurorRecordUrl(params) %}
+  {% set href = params.url('juror-record.overview.get', { jurorNumber: params.jurorNumber }) + "?loc_code=" + params.locCode %}
+
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ href }}">{{ params.jurorNumber }}</a>
+{% endmacro %}

--- a/client/templates/messaging/_partials/jurors-table.njk
+++ b/client/templates/messaging/_partials/jurors-table.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "custom-components/sortable-table/macro.njk" import modSortableTable %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-
+{% from "../_common/juror-record-url.macro.njk" import jurorRecordUrl %}
 
 {% set jurorRows = [] %}
 {% for juror in jurors %}
@@ -70,7 +70,11 @@
         classes: "mod-middle-align" + _highlightedRow
       },
       {
-        html: '<a class="govuk-link govuk-link--no-visited-state" href="' + url('juror-record.overview.get', {jurorNumber: juror['jurorNumber']}) + '">' + juror['jurorNumber'] + '</a>',
+        html: jurorRecordUrl({
+          url: url,
+          jurorNumber: juror['jurorNumber'],
+          locCode: juror['locCode']
+        }),
         classes: "mod-middle-align" + _highlightedRow
       },
       {

--- a/client/templates/messaging/export-contact-details/jurors-table.njk
+++ b/client/templates/messaging/export-contact-details/jurors-table.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "custom-components/sortable-table/macro.njk" import modSortableTable %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "../_common/juror-record-url.macro.njk" import jurorRecordUrl %}
 
 {% set jurorRows = [] %}
 {% for juror in jurors %}
@@ -24,7 +25,11 @@
         classes: "govuk-!-padding-right-2 govuk-!-padding-left-2"
       },
       {
-        html: '<a class="govuk-link govuk-link--no-visited-state" href="' + url('juror-record.overview.get', {jurorNumber: juror['jurorNumber']}) + '?loc_code='+ juror['locCode'] +'">' + juror['jurorNumber'] + '</a>',
+        html: jurorRecordUrl({
+          url: url,
+          jurorNumber: juror['jurorNumber'],
+          locCode: juror['locCode']
+        }),
         classes: "mod-middle-align"
       },
       {

--- a/client/templates/messaging/export-contact-details/jurors-table.njk
+++ b/client/templates/messaging/export-contact-details/jurors-table.njk
@@ -24,7 +24,7 @@
         classes: "govuk-!-padding-right-2 govuk-!-padding-left-2"
       },
       {
-        html: '<a class="govuk-link govuk-link--no-visited-state" href="' + url('juror-record.overview.get', {jurorNumber: juror['jurorNumber']}) + '">' + juror['jurorNumber'] + '</a>',
+        html: '<a class="govuk-link govuk-link--no-visited-state" href="' + url('juror-record.overview.get', {jurorNumber: juror['jurorNumber']}) + '?loc_code='+ juror['locCode'] +'">' + juror['jurorNumber'] + '</a>',
         classes: "mod-middle-align"
       },
       {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7764)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=623)


### Change description ###


the juror hyperlink is inconsistent some times it works other times it fails and says juror not found:



!image-20240713-141208.png|width=2013,height=609,alt="image-20240713-141208.png"!

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
