### PR TITLE
Existing trials not accessible post migration

### DIFF
--- a/server/config/validation/create-trial.js
+++ b/server/config/validation/create-trial.js
@@ -86,10 +86,10 @@
     }
 
     if (attributes.trialType === 'CRI') {
-      if (value.length > 16) {
+      if (value.length > 50) {
         tmpErrors = [{
-          summary: 'Defendant name must be 16 characters or less',
-          details: 'Defendant name must be 16 characters or less',
+          summary: 'Defendant name must be 50 characters or less',
+          details: 'Defendant name must be 50 characters or less',
         }];
       };
     }
@@ -112,10 +112,10 @@
     }
 
     if (attributes.trialType === 'CIV') {
-      if (value.length > 16) {
+      if (value.length > 50) {
         tmpErrors = [{
-          summary: 'Respondent name must be 16 characters or less',
-          details: 'Respondent name must be 16 characters or less',
+          summary: 'Respondent name must be 50 characters or less',
+          details: 'Respondent name must be 50 characters or less',
         }];
       };
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7792)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=624)


### Change description ###
Trials created before go-live weekend that are now not accessible - T20210487/0490 for Croydon. " issues;
1 - when you click on the trial is says page not found
2 - although the name was input in heritage on Friday, it is now saying that the defendant name is exceeding 16 characters


Heritage database supported up to 30 chars for trial.description

Modernised database supports 50 chars for trial.description

Backend API  supports 50 chars for Trial entity, description property

Front end is restricting to 16 chars - please update to match DB/BE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
