### PR TITLE
Court room dropdown autocomplete does not show for some courts

### DIFF
--- a/client/templates/trial-management/create-trial.njk
+++ b/client/templates/trial-management/create-trial.njk
@@ -105,16 +105,13 @@
       conditional: { 
         html: courtroomHtml
       },
-      checked: trialDetails.courtLocationName === court.courtLocationName
+      checked: trialDetails.courtLocationName === court.displayName
     }
   ), courtRadioItems) %}
 {% endfor %}
 
 {% block content %}
   {% include "includes/errors.njk" %}
-
-  {{ trialDetails | console }}
-  {{ courts | console }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -292,7 +289,7 @@
 
         {% for court in courts %}
 
-          {% if court.courtLocationName === trialDetails.courtLocationName %}
+          {% if court.displayName === trialDetails.courtLocationName %}
             $(document).ready(function () {
               const input = document.getElementById('{{court.courtLocationName}}-Courtroom');
               input.value = '{{trialDetails.courtroom}}';

--- a/client/templates/trial-management/create-trial.njk
+++ b/client/templates/trial-management/create-trial.njk
@@ -89,9 +89,9 @@
       label: {
         text: "Courtroom"
       },
-      value:  trialDetails[court.courtLocationName],
+      value: trialDetails[court.courtLocationName],
       name: court.courtLocationName,
-      id: court.courtLocationName,
+      id: court.courtLocationName + "-Courtroom",
       data: court.courtrooms,
       errorMessage: courtroomError,
       nonce: nonce
@@ -104,15 +104,17 @@
       text: court.displayName | capitalize,
       conditional: { 
         html: courtroomHtml
-      }
+      },
+      checked: trialDetails.courtLocationName === court.courtLocationName
     }
   ), courtRadioItems) %}
 {% endfor %}
 
-
-
 {% block content %}
   {% include "includes/errors.njk" %}
+
+  {{ trialDetails | console }}
+  {{ courts | console }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -130,10 +132,13 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         {% if editTrial %}
+
           <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">Case number</h2>
           <p class="govuk-body">{{ trialDetails.trialNumber }}</p>
           <input type="hidden" name="trialNumber" value="{{ trialDetails.trialNumber }}">
+
         {% else %}
+
           {{ govukInput({
             label: {
               text: "Case number"
@@ -144,7 +149,9 @@
             value: trialDetails.trialNumber,
             errorMessage: trialNumberError     
           }) }}
+
         {% endif %}
+
         {{ govukRadios({
           fieldset: {
             legend: {
@@ -199,7 +206,8 @@
           nonce: nonce
         }) }}
 
-        {% if courts|length > 1 %}
+        {% if courts | length > 1 %}
+
           {{ govukRadios({
             fieldset: {
               legend: {
@@ -212,8 +220,10 @@
             items: courtRadioItems,
             value: trialDetails.court,
             errorMessage: courtError
-        }) }}
+          }) }}
+
         {% else %}
+
           {{ modAutocomplete({
             label: {
               text: "Courtroom"
@@ -225,6 +235,7 @@
             errorMessage: courtroomError,
             nonce: nonce
           }) }}
+
         {% endif %}
 
         {{ govukCheckboxes({
@@ -247,7 +258,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton({
-        text: "Create trial",
+        text: "Edit trial" if editTrial else "Create trial",
         type: "submit",
         attributes: {
           id: "saveButton"
@@ -277,19 +288,23 @@
 
     {% if trialDetails.courtroom %}
       {# If there is more than one court to select from then need to handle which courtroom input to populate #}
-      {% if courts|length > 1 %}
+      {% if courts | length > 1 %}
+
         {% for court in courts %}
-          {% if court.locationName === trialDetails.court %}
+
+          {% if court.courtLocationName === trialDetails.courtLocationName %}
             $(document).ready(function () {
-              const input = document.getElementById('{{court.locationName}}' + 'Courtroom');
+              const input = document.getElementById('{{court.courtLocationName}}-Courtroom');
               input.value = '{{trialDetails.courtroom}}';
               isElementLoaded("[id$='Courtroom__option--0']").then((element) => {
-                document.querySelectorAll("[id$='Courtroom__option--0']").forEach(el=>el.click());
+                document.querySelectorAll("[id$='Courtroom__option--0']").forEach(el => el.click());
                 document.activeElement.blur();
-              });    
+              });
             });
           {% endif %}
+
         {% endfor %}
+
       {% else %}
         $(document).ready(function () {
           const input = document.getElementById('courtroom');
@@ -309,7 +324,7 @@
         isElementLoaded("#judge__option--0").then((element) => {
           element.click();
           document.activeElement.blur();
-        });    
+        });
       });
     {% endif %}
   </script>

--- a/server/routes/trial-management/create-trial/create-trial.controller.js
+++ b/server/routes/trial-management/create-trial/create-trial.controller.js
@@ -50,7 +50,7 @@
           req.session.courtrooms = courtrooms.map((court) => {
 
             court.display_name = court.court_location;
-            court.court_location = court.court_location.replace(/ /g, '_');
+            court.court_location = court.court_location.replace(/[ .]/g, '_');
 
             courtroomsToDisplay.push(
               {

--- a/server/routes/trial-management/edit-trial/edit-trial.controller.js
+++ b/server/routes/trial-management/edit-trial/edit-trial.controller.js
@@ -77,7 +77,7 @@
             judge: trial.judge.description,
             courtroom: trial.courtroom.description,
             protected: trial.protected ? 'true' : 'false',
-            courtLocationName: trial.court,
+            courtLocationName: trial.court_room_location_name,
           };
 
           req.session.orignalTrial = {

--- a/server/routes/trial-management/edit-trial/edit-trial.controller.js
+++ b/server/routes/trial-management/edit-trial/edit-trial.controller.js
@@ -53,7 +53,7 @@
           req.session.courtrooms = courtrooms.map((court) => {
 
             court.display_name = court.court_location;
-            court.court_location = court.court_location.replace(/ /g, '_');
+            court.court_location = court.court_location.replace(/[ .]/g, '_');
 
             courtroomsToDisplay.push(
               {
@@ -77,6 +77,7 @@
             judge: trial.judge.description,
             courtroom: trial.courtroom.description,
             protected: trial.protected ? 'true' : 'false',
+            courtLocationName: trial.court,
           };
 
           req.session.orignalTrial = {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7797)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=628)


### Change description ###
We should be able to see an input box that auto-completes with the court rooms.

!image-20240716-081514.png|width=821,height=206,alt="image-20240716-081514.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
