### PR TITLE
Trials created for a satellite court are saved with parent court

### DIFF
--- a/server/routes/juror-management/manage-jurors/manage-jurors.controller.js
+++ b/server/routes/juror-management/manage-jurors/manage-jurors.controller.js
@@ -27,7 +27,7 @@
           require('request-promise'),
           app,
           req.session.authToken,
-          req.session.authentication.owner,
+          req.session.authentication.locCode,
         );
 
         app.logger.info('Fetched pools at court location: ', {
@@ -41,7 +41,7 @@
             require('request-promise'),
             app,
             req.session.authToken,
-            req.session.authentication.owner,
+            req.session.authentication.locCode,
             'QUEUED'
           );
 
@@ -64,7 +64,7 @@
             auth: req.session.authentication,
             token: req.session.authToken,
             data: {
-              locationCode: req.session.authentication.owner,
+              locationCode: req.session.authentication.locCode,
               status: 'QUEUED',
             },
             error: typeof error.error !== 'undefined' ? error.error : error.toString(),
@@ -77,7 +77,7 @@
           auth: req.session.authentication,
           jwt: req.session.authToken,
           data: {
-            locationCode: req.session.authentication.owner,
+            locationCode: req.session.authentication.locCode,
           },
           error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
         });
@@ -104,7 +104,7 @@
         require('request-promise'),
         app,
         req.session.authToken,
-        req.session.authentication.owner,
+        req.session.authentication.locCode,
         'QUEUED'
       )
         .then((data) => {
@@ -123,7 +123,7 @@
             auth: req.session.authentication,
             token: req.session.authToken,
             data: {
-              locationCode: req.session.authentication.owner,
+              locationCode: req.session.authentication.locCode,
               status: 'QUEUED',
             },
             error: typeof err.error !== 'undefined' ? err.error : err.toString(),
@@ -149,7 +149,7 @@
         require('request-promise'),
         app,
         req.session.authToken,
-        req.session.authentication.owner,
+        req.session.authentication.locCode,
         status === 'pending' ? 'QUEUED' : ''
       )
         .then((data) => {
@@ -173,7 +173,7 @@
             auth: req.session.authentication,
             token: req.session.authToken,
             data: {
-              locationCode: req.session.authentication.owner,
+              locationCode: req.session.authentication.locCode,
               status: status === 'pending' ? 'QUEUED' : '',
             },
             error: typeof err.error !== 'undefined' ? err.error : err.toString(),

--- a/server/routes/messaging/send-messages.controller.js
+++ b/server/routes/messaging/send-messages.controller.js
@@ -51,7 +51,7 @@
           app,
           req,
           messagingCodes[message],
-          req.session.authentication.owner
+          req.session.authentication.locCode,
         );
 
         templateData = modUtils.replaceAllObjKeys(templateData, _.camelCase);
@@ -96,7 +96,7 @@
           token: req.session.authToken,
           data: {
             messageType: messagingCodes[message],
-            locCode: req.session.owner,
+            locCode: req.session.authentication.locCode,
           },
           error: typeof err.error !== 'undefined' ? err.error : err.toString(),
         });
@@ -449,7 +449,7 @@
         let jurorsData = await jurorSearchDAO.post(
           app,
           req,
-          req.session.authentication.owner,
+          req.session.authentication.locCode,
           opts
         );
 
@@ -585,7 +585,7 @@
           app,
           req,
           messagingCodes[message],
-          req.session.authentication.owner,
+          req.session.authentication.locCode,
           req.session.messaging.placeholderValues || {}
         );
 
@@ -620,7 +620,7 @@
           token: req.session.authToken,
           data: {
             messageType: messagingCodes[message],
-            locCode: req.session.owner,
+            locCode: req.session.authentication.locCode,
           },
           error: typeof err.error !== 'undefined' ? err.error : err.toString(),
         });
@@ -654,7 +654,7 @@
           app,
           req.session.authToken,
           messagingCodes[message],
-          req.session.authentication.owner,
+          req.session.authentication.locCode,
           payload,
         );
 
@@ -725,7 +725,7 @@
             let jurorsData = await jurorSearchDAO.post(
               app,
               req,
-              req.session.authentication.owner,
+              req.session.authentication.locCode,
               opts,
               true
             );

--- a/server/routes/trial-management/create-trial/create-trial.controller.js
+++ b/server/routes/trial-management/create-trial/create-trial.controller.js
@@ -177,7 +177,7 @@
       return cr.description === body.courtroom;
     });
 
-    payload.court_location = courtroom.owner;
+    payload.court_location = courtroom.loc_code;
     payload.courtroom_id = courtroom.id;
 
     payload.protected_trial = body.protected ? true : false;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7807)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=630)


### Change description ###
User MODTESTCOURT has access to CARDIFF (parent court) and NEWPORT S. WALES (satellite)
1. MODTESTCOURT selects to work under court CARDIFF, creates a trial with NEWPORT S. WALES as the court
2. MODTESTCOURT selects to work under court NEWPORT S. WALES, creates a trial with NEWPORT S. WALES as the court
RESULT: both are saved to the DB with CARDIFF as the court

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
