### PR TITLE
Uncaught Exceptions logging

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -223,9 +223,9 @@ module.exports = async (app) => {
   }
 
   process.on('uncaughtException', (error, origin) => {
-    app.logger.crit('Uncaught Exception', { origin, stackTrace: error.stack });
-
-    process.exit(1);
+    app.logger.crit('Uncaught Exception', { origin, stackTrace: error.stack }, () => {
+      process.exit(1);
+    });
   });
 
 };


### PR DESCRIPTION
### Links ###
N/A

### Change description ###
- put `process.exit(1)` into winstons callback function to only crash after the logs get posted to appinsights

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
