### PR TITLE
Redesign locking/unlocking confirm attendance for a day

### DIFF
--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -127,10 +127,7 @@
   function isAttendanceConfirmed(attendees) {
     if (!attendees.length) return false;
 
-    return attendees.filter(
-      (attendee) => !attendee.noShow
-        && !['EXPENSE_ENTERED', 'EXPENSE_AUTHORISED', 'EXPENSE_EDITED'].includes(attendee.appStage),
-    ).length === 0;
+    return attendees.filter(attendee => attendee.appearanceConfirmed).length > 0;
   }
 
 })();


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7791)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=637)


### Change description ###
Kingston court have reported they are unable to record attendance for today (15-07-2024)

Kingston appearance count data for last few days:

|attendance_date|confirmed_count|unconfirmed_count|
|15/07/2024|1|0|
|14/07/2024|0|1|
|12/07/2024|24|0|
|11/07/2024|108|3|

SQL code:


{noformat}select		attendance_date, 
			sum(case when appearance_stage = 'EXPENSE_ENTERED' then 1 else 0 end) as confirmed_count, 
			sum(case when appearance_stage <> 'EXPENSE_ENTERED' then 1 else 0 end) as unconfirmed_count
from 		juror_mod.appearance a
where 		loc_code = '427'
group by	attendance_date
order by	attendance_date desc;{noformat}

Today’s confirmed record is a no_show with appearance_stage set to EXPENSE_ENTERED.

The issue seems to be that the users are entering attendances for jurors via the *juror record* rather than the *juror management* screen. If they do that, it confirms the jurors attendance for the day and they will not be able to check in any more jurors.

The work around suggestion is to use the juror management screen to check in the jurors throughout the day and then confirm attendance at the end of the day. If there is a need to amend a jurors attendance after confirmation, then use the juror record attendance tab to update.

This is going to cause repeated issues and needs review/redesign - please can [~accountid:6102956a3900e60070a49b1a] / [~accountid:62c6b3412c528400c9b6dad5] work on a proposal for this?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
