### PR TITLE
When a juror is deferred or excuse from a paper response the green enter summons reply button still shows

### DIFF
--- a/client/templates/juror-management/_partials/heading.njk
+++ b/client/templates/juror-management/_partials/heading.njk
@@ -31,7 +31,7 @@
         }) }}
       {% endif %}
 
-      {% if canSummon %}
+      {% if canEnterSummons %}
         {{ govukButton({
           text: "Enter summons reply",
           href: url("paper-reply.index.get", { id: juror.commonDetails.jurorNumber })

--- a/client/templates/juror-management/_partials/heading.njk
+++ b/client/templates/juror-management/_partials/heading.njk
@@ -31,7 +31,7 @@
         }) }}
       {% endif %}
 
-      {% if not hasSummons and canSummon %}
+      {% if canSummon %}
         {{ govukButton({
           text: "Enter summons reply",
           href: url("paper-reply.index.get", { id: juror.commonDetails.jurorNumber })

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1302,6 +1302,8 @@
     switch (jurorStatus) {
     case 'Undeliverable':
     case 'Responded':
+    case 'Deferred':
+    case 'Excused':
     case 'Completed':
     case 'Disqualified':
       return false;

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1309,17 +1309,9 @@
       return false;
     }
 
-    switch (jurorStatus) {
-    case 'Undeliverable':
-    case 'Responded':
-    case 'Deferred':
-    case 'Excused':
-    case 'Completed':
-    case 'Disqualified':
-    case 'Deceased':
-    case 'Transferred':
+    if (jurorStatus !== 'Summoned') {
       return false;
-    };
+    }
 
     return !commonDetails.response_entered;
   }

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1305,6 +1305,10 @@
   function canEnterSummons(req, commonDetails) {
     const jurorStatus = resolveJurorStatus(commonDetails);
 
+    if (commonDetails.owner !== req.session.authentication.owner) {
+      return false;
+    }
+
     switch (jurorStatus) {
     case 'Undeliverable':
     case 'Responded':
@@ -1312,10 +1316,11 @@
     case 'Excused':
     case 'Completed':
     case 'Disqualified':
+    case 'Deceased':
       return false;
     };
 
-    return isBureauUser(req) && !commonDetails.response_entered;
+    return !commonDetails.response_entered;
   }
 
 })();

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1297,6 +1297,16 @@
   }
 
   function canSummon(req, commonDetails) {
+    const jurorStatus = resolveJurorStatus(commonDetails);
+
+    switch (jurorStatus) {
+    case 'Undeliverable':
+    case 'Responded':
+    case 'Completed':
+    case 'Disqualified':
+      return false;
+    };
+
     return isBureauUser(req) && !commonDetails.response_entered;
   }
 

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -3,7 +3,7 @@
   
   const _ = require('lodash');
   const { dateFilter, capitalizeFully, makeDate } = require('../../../components/filters');
-  const { isCourtUser } = require('../../../components/auth/user-type');
+  const { isCourtUser, isBureauUser } = require('../../../components/auth/user-type');
   const jurorRecordObject = require('../../../objects/juror-record');
   const { jurorHistoryDAO, jurorPaymentsHistoryDAO } = require('../../../objects/juror-history');
   const validate = require('validate.js');
@@ -42,7 +42,6 @@
             currentTab: 'details',
             jurorStatus: resolveJurorStatus(response.data.commonDetails),
             canSummon: canSummon(req, response.data.commonDetails),
-            hasSummons: response.data.commonDetails.hasSummonsResponse,
             isCourtUser: isCourtUser(req),
           });
         }
@@ -149,7 +148,6 @@
             policeCheck: resolvePoliceCheckStatus(req, overview.data.commonDetails.police_check),
             bannerMessage: bannerMessage,
             availableMessage: availableMessage,
-            hasSummons: overview.data.commonDetails.hasSummonsResponse,
             poolDetails,
             idCheckDescription,
             attendance,
@@ -234,7 +232,6 @@
             processingOutcome: modUtils.resolveProcessingOutcome(response.data.commonDetails.jurorStatus,
               response.data.commonDetails.excusalRejected, response.data.commonDetails.excusalDescription),
             canSummon: canSummon(req, response.data.commonDetails),
-            hasSummons: response.data.commonDetails.hasSummonsResponse,
           });
         }
         , errorCB = function(err) {
@@ -331,7 +328,6 @@
             jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
             currentTab: 'expenses',
             canSummon: canSummon(req, jurorOverview.data.commonDetails),
-            hasSummons: jurorOverview.data.commonDetails.hasSummonsResponse,
             dailyExpenses,
             defaultExpenses,
             bankDetails,
@@ -358,7 +354,6 @@
                 jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
                 currentTab: 'expenses',
                 canSummon: canSummon(req, jurorOverview.data.commonDetails),
-                hasSummons: jurorOverview.data.commonDetails.hasSummonsResponse,
                 dailyExpenses,
                 defaultExpenses,
                 bankDetails,
@@ -468,7 +463,6 @@
           processingOutcome: modUtils.resolveProcessingOutcome(jurorOverview.data.commonDetails.jurorStatus,
             jurorOverview.data.commonDetails.excusalRejected, jurorOverview.data.commonDetails.excusalDescription),
           canSummon: canSummon(req, jurorOverview.data.commonDetails),
-          hasSummons: jurorOverview.data.commonDetails.hasSummonsResponse,
           attendance,
           formattedDate,
           failedToAttend,
@@ -538,7 +532,6 @@
             contactLogs: contactLogs,
             canSummon: canSummon(req, response[0].data.commonDetails),
             jurorStatus: resolveJurorStatus(response[0].data.commonDetails),
-            hasSummons: response[0].data.commonDetails.hasSummonsResponse,
           });
         }
         , errorCB = function(err) {
@@ -1075,7 +1068,6 @@
         historyUrl: app.namedRoutes.build('juror-record.history.get', { jurorNumber }),
         historyTab,
         canSummon: canSummon(req, juror.commonDetails),
-        hasSummons: juror.commonDetails.hasSummonsResponse,
         printUrl: app.namedRoutes.build('juror-record.history.print.get', { jurorNumber }),
         history,
         currentTab: 'history',
@@ -1305,23 +1297,7 @@
   }
 
   function canSummon(req, commonDetails) {
-    const jurorStatus = resolveJurorStatus(commonDetails);
-    let canSummon = true;
-
-    if (commonDetails.owner !== '400' && !isCourtUser(req)) {
-      canSummon = false;
-    };
-
-    switch (jurorStatus) {
-    case 'Undeliverable':
-    case 'Responded':
-    case 'Completed':
-    case 'Disqualified':
-      canSummon = false;
-      break;
-    };
-
-    return canSummon;
+    return isBureauUser(req) && !commonDetails.response_entered;
   }
 
 })();

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -3,7 +3,7 @@
   
   const _ = require('lodash');
   const { dateFilter, capitalizeFully, makeDate } = require('../../../components/filters');
-  const { isCourtUser, isBureauUser } = require('../../../components/auth/user-type');
+  const { isCourtUser } = require('../../../components/auth/user-type');
   const jurorRecordObject = require('../../../objects/juror-record');
   const { jurorHistoryDAO, jurorPaymentsHistoryDAO } = require('../../../objects/juror-history');
   const validate = require('validate.js');

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -41,7 +41,7 @@
             juror: response.data,
             currentTab: 'details',
             jurorStatus: resolveJurorStatus(response.data.commonDetails),
-            canSummon: canSummon(req, response.data.commonDetails),
+            canEnterSummons: canEnterSummons(req, response.data.commonDetails),
             isCourtUser: isCourtUser(req),
           });
         }
@@ -141,7 +141,7 @@
           return res.render('juror-management/juror-record/overview', {
             backLinkUrl: 'homepage.get',
             juror: overview.data,
-            canSummon: canSummon(req, overview.data.commonDetails),
+            canEnterSummons: canEnterSummons(req, overview.data.commonDetails),
             currentTab: 'overview',
             jurorStatus,
             canRunPoliceCheck,
@@ -231,7 +231,7 @@
             replyStatus: modUtils.resolveReplyStatus(response.data.replyStatus),
             processingOutcome: modUtils.resolveProcessingOutcome(response.data.commonDetails.jurorStatus,
               response.data.commonDetails.excusalRejected, response.data.commonDetails.excusalDescription),
-            canSummon: canSummon(req, response.data.commonDetails),
+            canEnterSummons: canEnterSummons(req, response.data.commonDetails),
           });
         }
         , errorCB = function(err) {
@@ -327,7 +327,7 @@
             juror: jurorOverview.data,
             jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
             currentTab: 'expenses',
-            canSummon: canSummon(req, jurorOverview.data.commonDetails),
+            canEnterSummons: canEnterSummons(req, jurorOverview.data.commonDetails),
             dailyExpenses,
             defaultExpenses,
             bankDetails,
@@ -353,7 +353,7 @@
                 juror: jurorOverview.data,
                 jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
                 currentTab: 'expenses',
-                canSummon: canSummon(req, jurorOverview.data.commonDetails),
+                canEnterSummons: canEnterSummons(req, jurorOverview.data.commonDetails),
                 dailyExpenses,
                 defaultExpenses,
                 bankDetails,
@@ -462,7 +462,7 @@
           jurorStatus: resolveJurorStatus(jurorOverview.data.commonDetails),
           processingOutcome: modUtils.resolveProcessingOutcome(jurorOverview.data.commonDetails.jurorStatus,
             jurorOverview.data.commonDetails.excusalRejected, jurorOverview.data.commonDetails.excusalDescription),
-          canSummon: canSummon(req, jurorOverview.data.commonDetails),
+          canEnterSummons: canEnterSummons(req, jurorOverview.data.commonDetails),
           attendance,
           formattedDate,
           failedToAttend,
@@ -530,7 +530,7 @@
             juror: response[0].data,
             currentTab: 'notes',
             contactLogs: contactLogs,
-            canSummon: canSummon(req, response[0].data.commonDetails),
+            canEnterSummons: canEnterSummons(req, response[0].data.commonDetails),
             jurorStatus: resolveJurorStatus(response[0].data.commonDetails),
           });
         }
@@ -1067,7 +1067,7 @@
         jurorStatus: resolveJurorStatus(juror.commonDetails),
         historyUrl: app.namedRoutes.build('juror-record.history.get', { jurorNumber }),
         historyTab,
-        canSummon: canSummon(req, juror.commonDetails),
+        canEnterSummons: canEnterSummons(req, juror.commonDetails),
         printUrl: app.namedRoutes.build('juror-record.history.print.get', { jurorNumber }),
         history,
         currentTab: 'history',
@@ -1296,7 +1296,7 @@
     return Promise.resolve(description);
   }
 
-  function canSummon(req, commonDetails) {
+  function canEnterSummons(req, commonDetails) {
     const jurorStatus = resolveJurorStatus(commonDetails);
 
     switch (jurorStatus) {

--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1317,6 +1317,7 @@
     case 'Completed':
     case 'Disqualified':
     case 'Deceased':
+    case 'Transferred':
       return false;
     };
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7757)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=646)


### Change description ###
the processing status is summoned these need to be moved to completed for all paper responses that have moved out of summoned status.

Also occurs when a juror response is deleted (apart of the one year juror_digital housekeeping).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
