### PR TITLE
cannot add an attendance day via juror record for a satellite court

### DIFF
--- a/server/routes/juror-management/attendance/add-attendance-date/add-attendance-date.controller.js
+++ b/server/routes/juror-management/attendance/add-attendance-date/add-attendance-date.controller.js
@@ -116,7 +116,7 @@
         const payload = {
           'juror_number': jurorNumber,
           'pool_number': req.session.jurorCommonDetails.poolNumber,
-          'location_code': req.session.authentication.owner,
+          'location_code': req.session.authentication.locCode,
           'attendance_date': dateFilter(req.body.attendanceDay, 'DD/MM/YYYY', 'YYYY-MM-DD'),
           'check_in_time': convertTimeToHHMM(req.body.checkInTimeHour,
             req.body.checkInTimeMinute, req.body.checkInTimePeriod),


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7872)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=651)


### Change description ###
Thoughg I can add attendance (and conform it) via juror management-record attendance

!image-20240721-160554.png|width=1320,height=706,alt="image-20240721-160554.png"!



!image-20240721-160655.png|width=1359,height=282,alt="image-20240721-160655.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
