### PR TITLE
INC2529075 - Unable to edit expenses for approval [HMCTS Ref INC5632495]

### DIFF
--- a/server/routes/juror-management/expenses/edit/edit-approval-expenses.controller.js
+++ b/server/routes/juror-management/expenses/edit/edit-approval-expenses.controller.js
@@ -96,6 +96,7 @@
               && originalExpense.food_and_drink === expense.food_and_drink
               && originalExpense.payment_method === expense.payment_method
               && originalExpense.smart_card === expense.smart_card
+              && originalExpense.public_transport === expense.public_transport
             ) {
               delete originalExpenses[expense.attendance_date];
               delete req.session.editedExpenses[expense.attendance_date];


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7888)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=657)


### Change description ###
When user is attempting to edit expense for approval they get an error message. 

Steps to replicate (STR): Juror Number 441317934 > Expenses > Total for approval: View > Mon 01 Jul 2024 > Edit expenses for approval > Change Public transport from 8.60 to 0.00 > Recalculate totals > Save and back to all days > P. transport column showing £0.00 > Submit for approval > Error received "There is a problem. Edit at least one expense before submitting" and P. transport column resets to £8.60. Screenshots attached.



!image-20240723-105349.png|width=1187,height=852,alt="image-20240723-105349.png"!



!image-20240723-105411.png|width=1140,height=854,alt="image-20240723-105411.png"!



!image-20240723-105434.png|width=945,height=641,alt="image-20240723-105434.png"!





!image-20240723-105500.png|width=793,height=654,alt="image-20240723-105500.png"!



!image-20240723-105525.png|width=1184,height=405,alt="image-20240723-105525.png"!



!image-20240723-105744.png|width=1131,height=591,alt="image-20240723-105744.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
