### PR TITLE
Trials - pagination not showing for lists larger than 25

### DIFF
--- a/server/routes/trial-management/trial-management.controller.js
+++ b/server/routes/trial-management/trial-management.controller.js
@@ -42,7 +42,7 @@
             },
           });
 
-          const queryTotal = data.totalItems;
+          const queryTotal = data.total_items;
 
           if (queryTotal > modUtils.constants.PAGE_SIZE) {
             pagination = modUtils.paginationBuilder(queryTotal, currentPage, req.url);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7897)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=662)


### Change description ###
If a court has more than 25 trials the user is not able to paginate through them and so cant see more than the initial 25.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
