### PR TITLE
Record attendance check out issue

### DIFF
--- a/client/templates/juror-management/attendance/unconfirmed/unconfirmed.njk
+++ b/client/templates/juror-management/attendance/unconfirmed/unconfirmed.njk
@@ -117,7 +117,7 @@
     {{ govukButton({
       text: "Check out all jurors",
       classes: "govuk-button--secondary govuk-!-margin-bottom-1",
-      type: "submit"
+      type: "button"
     }) }}
     <input type="hidden" name="_csrf" id="checkOutcsrfToken" value="{{ csrftoken }}"/>
   </form>

--- a/client/templates/juror-management/attendance/unconfirmed/unconfirmed.njk
+++ b/client/templates/juror-management/attendance/unconfirmed/unconfirmed.njk
@@ -106,7 +106,7 @@
         {{ govukButton({
           text: "Check out juror",
           classes: "govuk-!-margin-bottom-1",
-          type: "button",
+          type: "submit",
           attributes: {
             id: "checkOutSingleJuror"
           }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7916)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=664)


### Change description ###
On record attendance screen, when a user presses the enter key to check out a juror, it is automatically defaulting to confirm all the jurors check out time rather than just an individual one

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
