### PR TITLE
Juror history links need updating

### DIFF
--- a/client/templates/juror-management/_partials/attendance-tab.njk
+++ b/client/templates/juror-management/_partials/attendance-tab.njk
@@ -52,8 +52,8 @@
             {% for item in history.paymentDays %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">{{ item.attendanceDate | dateFilter(null, 'ddd d MMM YYYY') }}</td>
-                <td class="govuk-table__cell">{{ item.attendanceAudit | historyAuditLinkify | safe }}</td>
-                <td class="govuk-table__cell">{{ (item.paymentAudit | historyAuditLinkify | safe) if item.paymentAudit else '-' }}</td>
+                <td class="govuk-table__cell">{{ item.attendanceAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser) | safe }}</td>
+                <td class="govuk-table__cell">{{ (item.paymentAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser) | safe) if item.paymentAudit else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.datePaid | dateFilter(null, 'd MMM YYYY')) if item.datePaid else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.timePaid | convert24to12) if (item.timePaid or item.paymentAudit) else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.travel | toMoney) if (item.travel or item.paymentAudit) else '-' }}</td>

--- a/client/templates/juror-management/_partials/history-tab.njk
+++ b/client/templates/juror-management/_partials/history-tab.njk
@@ -14,7 +14,7 @@
     
     {% set historyHtml %}
       {% for historyDetails in historyItem.historyDetails %}
-        <div class='entry'>{{historyDetails | historyAuditLinkify | safe}}</div>
+        <div class='entry'>{{historyDetails | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser) | safe}}</div>
       {% endfor %}
     {% endset %}
 

--- a/server/components/filters/index.js
+++ b/server/components/filters/index.js
@@ -518,7 +518,11 @@
       }).join('');
     },
 
-    historyAuditLinkify: function(copy) {
+    historyAuditLinkify: function(copy, locCode, isCourt = true) {
+      if (!isCourt) {
+        return copy;
+      }
+
       const parts = copy?.split(/([A-Z][0-9]+)/g);
       
       return parts?.map((item) => {
@@ -533,7 +537,7 @@
             return `<a href="/reporting/jury-attendance-audit/report/${item}/print" target="_blank">${item}</a>`;
           }
           if (item.startsWith('T')) {
-            return `<a href="#" target="_blank">${item}</a>`;
+            return `<a href="/trial-management/trials/${item}/${locCode}/detail" target="_blank">${item}</a>`;
           }
         }
         

--- a/server/components/filters/index.js
+++ b/server/components/filters/index.js
@@ -518,7 +518,7 @@
       }).join('');
     },
 
-    historyAuditLinkify: function(copy, locCode, isCourt = true) {
+    historyAuditLinkify: function(copy, locCode, isCourt) {
       if (!isCourt) {
         return copy;
       }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7813)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=673)


### Change description ###
The Juror history screen shows links to trials and attendance audits but the URL points to financial-audit. This needs updating on the FE to point to correct URL.

!image-20240716-170302.png|width=932,height=780,alt="image-20240716-170302.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
