### PR TITLE
Add add attendance day and none attendance day for panel status jurors

### DIFF
--- a/client/templates/juror-management/juror-record/attendance.njk
+++ b/client/templates/juror-management/juror-record/attendance.njk
@@ -104,7 +104,7 @@
     </div>
   </div>
   <span>
-    {% if juror.commonDetails.loc_code === authentication.locCode and (juror.commonDetails.jurorStatus == 'Responded' or juror.commonDetails.jurorStatus == 'Panelled' or juror.commonDetails.jurorStatus == 'Juror' or juror.commonDetails.jurorStatus == 'Completed') %}
+    {% if juror.commonDetails.loc_code === authentication.locCode and (juror.commonDetails.jurorStatus == 'Responded' or juror.commonDetails.jurorStatus == 'Panel' or juror.commonDetails.jurorStatus == 'Juror' or juror.commonDetails.jurorStatus == 'Completed') %}
       {{ govukButton({
         text: "Add attendance day",
         href: url('juror-record.attendance.add-attendance-date.get', {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7846)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=674)


### Change description ###
When a juror is in panelled status we need to be able to add attendance and non attendance days via the juror record

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
