### PR TITLE
hotfix/JM-7951: Redirect to summons reply on processing response

### DIFF
--- a/client/templates/response/detail.njk
+++ b/client/templates/response/detail.njk
@@ -26,7 +26,7 @@
     }
   }) }}
 
-  {% if response.processingStatus === 'Closed' %}
+  {% if response.processingStatus in ['Closed', 'CLOSED'] %}
     <div class="govuk-!-margin-top-3">
       {% set bannerMessageHtml %}
         Summons reply processed on {{ response.completedAt | dateFilter('DD/MM/YYYY', 'D MMMM YYYY') }} by {{ response.assignedStaffMember.name | isAutoProcessed }}: <b>{{ processedBannerMessage }}</b>

--- a/server/routes/response/detail/detail.controller.js
+++ b/server/routes/response/detail/detail.controller.js
@@ -1718,7 +1718,7 @@
               type: 'Responded',
             };
 
-            return res.redirect(app.namedRoutes.build('inbox.todo.get'));
+            return res.redirect(app.namedRoutes.build('response.detail.get', {id: req.params.id}));
           }
 
           return res.redirect(app.namedRoutes.build('response.detail.get', {id: req.params.id}));
@@ -1792,7 +1792,7 @@
               type: 'Responded',
             };
 
-            return res.redirect(app.namedRoutes.build('inbox.todo.get'));
+            return res.redirect(app.namedRoutes.build('response.paper.details.get', {id: req.params.id, type:'paper'}));
           }
         }).catch(errorCB);
       }

--- a/server/routes/summons-management/process-reply/disqualify/process-reply-disqualify.controller.js
+++ b/server/routes/summons-management/process-reply/disqualify/process-reply-disqualify.controller.js
@@ -109,7 +109,11 @@
             return res.redirect(app.namedRoutes.build('process-disqualify.letter.get', routeParameters));
           }
 
-          return res.redirect(app.namedRoutes.build('inbox.todo.get'));
+          if (routeParameters.type === 'paper') {
+            return res.redirect(app.namedRoutes.build('response.paper.details.get', routeParameters));
+          }
+          return res.redirect(app.namedRoutes.build('response.detail.get', routeParameters));
+
         }).catch((err) => {
           app.logger.crit('Failed to process juror disqualification', {
             auth: req.session.authentication,

--- a/server/routes/summons-management/process-reply/reassign-before-process/reassign-before-process.controller.js
+++ b/server/routes/summons-management/process-reply/reassign-before-process/reassign-before-process.controller.js
@@ -13,11 +13,6 @@
     { systemCodesDAO } = require('../../../../objects/administration'),
     excusalObj = require('../../../../objects/excusal-mod.js').excusalObject,
     excusalValidator = require('../../../../config/validation/excusal-mod.js'),
-    actionPaths = {
-      responded: 'response.detail.responded.get',
-      deferral: 'process-deferral-dates.get',
-      excused: 'inbox.todo.get',
-    },
     requestObj = require('../../../../objects/pool-management.js').reassignJurors;
 
   module.exports.getReassignBeforeProcess = (app) => {
@@ -122,7 +117,7 @@
       }).then(
         (court) => {
           if (court.locationCode === req.session.locCode) {
-            return res.redirect(app.namedRoutes.build(actionPaths[req.params.action], {
+            return res.redirect(app.namedRoutes.build(actionPaths(req.params.action, req.params.type), {
               id: req.params.id,
               type: req.params.type,
             }));
@@ -131,7 +126,7 @@
           req.session.receivingCourtLocCode = court.locationCode;
 
           if (req.params.action === 'deferral') {
-            return res.redirect(app.namedRoutes.build(actionPaths[req.params.action], {
+            return res.redirect(app.namedRoutes.build(actionPaths(req.params.action, req.params.type), {
               id: req.params.id,
               type: req.params.type,
             }));
@@ -261,7 +256,7 @@
             req.session.locCode = req.session.receivingCourtLocCode;
             delete req.session.receivingCourtLocCode;
 
-            return res.redirect(app.namedRoutes.build(actionPaths[req.params.action], {
+            return res.redirect(app.namedRoutes.build(actionPaths(req.params.action, req.params.type), {
               id: req.params.id,
               type: req.params.type,
             }));
@@ -489,7 +484,10 @@
 
             delete req.session.excusalReasons;
 
-            return res.redirect(app.namedRoutes.build('inbox.todo.get'));
+            if (req.params.type === 'paper') {
+              return res.redirect(app.namedRoutes.build('response.paper.details.get', req.params));
+            }
+            return res.redirect(app.namedRoutes.build('response.detail.get', req.params));
           }
         )
         .catch(
@@ -506,5 +504,14 @@
         );
     };
   };
+
+  function actionPaths(action, responseType) {
+    const actionPaths = {
+      responded: 'response.detail.responded.get',
+      deferral: 'process-deferral-dates.get',
+      excused: responseType === 'paper' ? 'response.paper.details.get' : 'response.detail.get',
+    }
+    return actionPaths[action];
+  }
 
 })();

--- a/server/routes/summons-management/summons-management.controller.js
+++ b/server/routes/summons-management/summons-management.controller.js
@@ -425,8 +425,10 @@
             return res.redirect(app.namedRoutes.build('process-deferral.letter.get', routeParameters));
           }
 
-          return res.redirect(app.namedRoutes.build('inbox.todo.get'));
-
+          if (routeParameters.type === 'paper') {
+            return res.redirect(app.namedRoutes.build('response.paper.details.get', routeParameters));
+          }
+          return res.redirect(app.namedRoutes.build('response.detail.get', routeParameters));
         }
         , errorCB = function(err) {
           app.logger.crit('Failed to process Deferral: ', {
@@ -635,7 +637,10 @@
             }));
           }
 
-          return res.redirect(app.namedRoutes.build('inbox.todo.get'));
+          if (routeParameters.type === 'paper') {
+            return res.redirect(app.namedRoutes.build('response.paper.details.get', routeParameters));
+          }
+          return res.redirect(app.namedRoutes.build('response.detail.get', routeParameters));
         }
         , errorCB = function(err) {
           app.logger.crit('Failed to process excusal: ', {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7951

### Change description ###
From Andy
_"When processing a paper or digital reply for the Bureau, once they have completed their action the page is redirected to the “Your Work” screen. However, Juror Digital previously remained on the response details page to allow them to add any notes/log/RA’s that were needed.
As the system currently directs you back to the “Your Work” screen, its taking longer to go into the complete tab and search for the juror that they have just completed a response for. 
It would be more suitable to the business to remain in the response details page."_

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
