### PR TITLE
Payment audit report - everyone still showing 1st January 2000 as the submitted date

### DIFF
--- a/server/lib/reports/financial-audit.js
+++ b/server/lib/reports/financial-audit.js
@@ -96,14 +96,24 @@
     } = auditData;
 
     const right = financialAuditNumber ? [
-      {key: 'Audit number', value: financialAuditNumber},
-      {key: 'Date submitted', value: `${dateFilter(submittedAt, '', 'ddd DD MMM YYYY')} by ${submittedBy.name}`},
+      { key: 'Audit number', value: financialAuditNumber},
+      {
+        key: 'Date submitted',
+        value: submittedAt.includes('2000-01-01')
+          ? '-' : `${dateFilter(submittedAt, '', 'ddd DD MMM YYYY')} by ${submittedBy.name}`,
+      },
      ] : [
-      {key: 'Audit number', value: 'Draft'},
-     ]
+      { key: 'Audit number', value: 'Draft' },
+     ];
 
     if (approvedAt) {
-      right.push({key: 'Date approved', value: `${dateFilter(approvedAt, '', 'ddd DD MMM YYYY')} by ${approvedBy.name}`})
+      right.push(
+        {
+          key: 'Date approved',
+          value: approvedAt.includes('2000-01-01')
+            ? '-' : `${dateFilter(approvedAt, '', 'ddd DD MMM YYYY')} by ${approvedBy.name}`,
+        },
+      );
     }
 
     const method = auditData.expenses.expenseDetails.reduce((prev, curr) => {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7923)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=684)


### Change description ###
With a good date:

!image-20240802-095922.png|width=428,height=244,alt="image-20240802-095922.png"!


With the default date:

!image-20240802-095757.png|width=409,height=231,alt="image-20240802-095757.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
