### PR TITLE
Error message is displayed wrong when checkout time < check in time

### DIFF
--- a/server/routes/juror-management/attendance/attendance.controller.js
+++ b/server/routes/juror-management/attendance/attendance.controller.js
@@ -4,7 +4,7 @@
   const _ = require('lodash');
   const validate = require('validate.js');
   const checkOutAllValidator = require('../../../config/validation/check-out-all-jurors');
-  const { getJurorStatus, padTimeForApi, mapCamelToSnake } = require('../../../lib/mod-utils');
+  const { getJurorStatus, padTimeForApi, mapCamelToSnake, makeManualError } = require('../../../lib/mod-utils');
   const { convertAmPmToLong, convert12to24, timeArrayToString,
     timeStringToArray } = require('../../../components/filters');
   const { jurorsAttending, jurorAttendanceDao } = require('../../../objects/juror-attendance');
@@ -185,7 +185,9 @@
       const checkOutTime = convertAmPmToLong(req.body.time);
 
       if (latestStartTime >= checkOutTime) {
-        return res.status(400).send('check out earlier than check in');
+        req.session.formFields = req.body;
+        req.session.errors = makeManualError('checkOutTimeHour', 'Check out time cannot be earlier than check in time')
+        return res.redirect(app.namedRoutes.build('juror-management.attendance.get') + '?date=' + attendanceDate);
       }
 
       let panelledJurors = [];


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7900)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
It is correct (my checkout time is earlier than my checkin time), but the error is displayed incorrectly

!image-20240724-100921.png|width=773,height=166,alt="image-20240724-100921.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
