### PR TITLE
Deferral Maintenance uses owner instead of locCode when returning deferred jurors

### DIFF
--- a/server/routes/pool-management/deferral-maintenance/deferral-maintenance.controller.js
+++ b/server/routes/pool-management/deferral-maintenance/deferral-maintenance.controller.js
@@ -68,8 +68,8 @@
 
       if (isCourtUser(req) && !req.session.errors) {
         return requestObj
-          .deferrals.get(rp, app, req.session.authToken, req.session.authentication.owner)
-          .then((data) => successCB(data, req.session.authentication.owner)(app, req, res))
+          .deferrals.get(rp, app, req.session.authToken, req.session.authentication.locCode)
+          .then((data) => successCB(data, req.session.authentication.locCode)(app, req, res))
           .catch((err) => errorCB(err)(app, req, res));
       }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7986)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=692)


### Change description ###


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
