### PR TITLE
INC2543948 - The user tried to request a pool and the request failed but the application did not show an error message

### DIFF
--- a/client/templates/pool-management/_common/check-request-details.njk
+++ b/client/templates/pool-management/_common/check-request-details.njk
@@ -10,6 +10,8 @@
 
 {% block content %}
 
+  {% include "includes/errors.njk" %}
+
   {% set _submitUrl = submitUrl %}
   {% set _cancelUrl = cancelUrl %}
   {% set _changeUrl = changeUrl %}

--- a/server/routes/pool-management/request-pool/request-pool.controller.js
+++ b/server/routes/pool-management/request-pool/request-pool.controller.js
@@ -457,6 +457,10 @@
             poolDetails.numberOfCourtDeferrals = poolDetails.numberOfJurorsRequired;
           }
 
+          const tmpErrors = _.clone(req.session.errors);
+
+          delete req.session.errors;
+
           return res.render('pool-management/_common/check-request-details', {
             poolDetails: poolDetails,
             submitUrl: app.namedRoutes.build('request-pool.check-details.post'),
@@ -466,6 +470,11 @@
             pageIdentifier: 'Request a Pool',
             pageTitle: 'Check your pool request',
             buttonLabel: 'Request pool',
+            errors: {
+              title: 'Please check all details',
+              count: typeof tmpErrors !== 'undefined' ? Object.keys(tmpErrors).length : 0,
+              items: tmpErrors,
+            },
           });
         },
         errorCB = function(err) {
@@ -527,7 +536,9 @@
             error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
           });
 
-          return res.redirect(app.namedRoutes.build('pool-management.get'));
+          req.session.errors = modUtils.makeManualError('poolRequest', 'Something went wrong when trying to request a new pool');
+
+          return res.redirect(app.namedRoutes.build('request-pool.check-details.get'));
         };
 
       tmpBody.attendanceTime = req.session.poolDetails.attendanceTime;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7980)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Because the application did not show an error message it is fair to assume nothing went wrong. We should display an error message when a pool request fails to create.



Court: {{Liverpool 433}} on {{2024-07-26T11:06:23.46Z}}



{noformat}Validation failed for classes [uk.gov.hmcts.juror.api.moj.domain.Juror] during update time for groups [jakarta.validation.groups.Default, ]
List of constraint violations:[
ConstraintViolationImpl{interpolatedMessage='must match "^$|(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$"', propertyPath=postcode, rootBeanClass=class uk.gov.hmcts.juror.api.moj.domain.Juror, messageTemplate='{jakarta.validation.constraints.Pattern.message}'}
]{noformat}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
