### PR TITLE
Update expenses tables to not show the default date set (2000-01-01)

### DIFF
--- a/client/templates/juror-management/_partials/attendance-tab.njk
+++ b/client/templates/juror-management/_partials/attendance-tab.njk
@@ -54,7 +54,13 @@
                 <td class="govuk-table__cell">{{ item.attendanceDate | dateFilter(null, 'ddd d MMM YYYY') }}</td>
                 <td class="govuk-table__cell">{{ item.attendanceAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser) | safe }}</td>
                 <td class="govuk-table__cell">{{ (item.paymentAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser) | safe) if item.paymentAudit else '-' }}</td>
-                <td class="govuk-table__cell">{{ (item.datePaid | dateFilter(null, 'd MMM YYYY')) if item.datePaid else '-' }}</td>
+                <td class="govuk-table__cell">
+                  {% if "2000-01-01" in item.datePaid %}
+                    -
+                  {% else %}
+                    {{ (item.datePaid | dateFilter(null, 'D MMM YYYY')) if item.datePaid else '-' }}
+                  {% endif %}
+                </td>
                 <td class="govuk-table__cell">{{ (item.timePaid | convert24to12) if (item.timePaid or item.paymentAudit) else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.travel | toMoney) if (item.travel or item.paymentAudit) else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.financialLoss | toMoney) if (item.financialLoss or item.paymentAudit) else '-' }}</td>

--- a/client/templates/juror-management/expense-record/_partials/approval-table.njk
+++ b/client/templates/juror-management/expense-record/_partials/approval-table.njk
@@ -71,7 +71,13 @@
           {% if status === "for-reapproval" %}
             <td class="govuk-table__cell"><b>£{{ expense.balance_to_pay | toFixed(2) }}</b></td>
           {% endif %}
-          <td class="govuk-table__cell" data-sort-value="{{ expense.audit_created_on }}">{{ expense.audit_created_on | dateFilter("YYYY-MM-DD hh:mm:ss", "ddd DD MMM YYYY [at] h:mma") }}</td>
+          <td class="govuk-table__cell" data-sort-value="{{ expense.audit_created_on }}">
+            {% if "2000-01-01" in expense.audit_created_on %}
+              -
+            {% else %}
+              {{ expense.audit_created_on | dateFilter("YYYY-MM-DD hh:mm:ss", "ddd DD MMM YYYY [at] h:mma") }}
+            {% endif %}
+          </td>
         </tr>
 
       {% endfor %}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7990)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=697)


### Change description ###
We have updated the reports to show a blank field but left some tables out.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
