### PR TITLE
Application crashes on trying to search for reports that need a date-range

### DIFF
--- a/client/templates/reporting/standard-reports/date-search/fixed-range.njk
+++ b/client/templates/reporting/standard-reports/date-search/fixed-range.njk
@@ -29,5 +29,6 @@
       },
       checked:  tmpBody.dateRange === 'CUSTOM_RANGE'
     } if "CUSTOM_RANGE" in fixedDateRangeValues
-  ]
+  ],
+  errorMessage: dateRangeError
 }) }}

--- a/server/config/validation/report-search-by.js
+++ b/server/config/validation/report-search-by.js
@@ -182,6 +182,26 @@
         summary: 'Enter a date to search attendances up until',
         details: 'Enter a date to search attendances up until',
       }],
+    },
+    unconfirmedAttendance: {
+      dateFrom: [{
+        summary: 'Enter a date to search unconfirmed attendances from',
+        details: 'Enter a date to search unconfirmed attendances from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search unconfirmed attendances up until',
+        details: 'Enter a date to search unconfirmed attendances up until',
+      }],
+    },
+    juryExpenditureLowLevel: {
+      dateFrom: [{
+        summary: 'Enter a date to search from',
+        details: 'Enter a date to search from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search up until',
+        details: 'Enter a date to search up until',
+      }],
     }
   };
 

--- a/server/config/validation/report-search-by.js
+++ b/server/config/validation/report-search-by.js
@@ -68,6 +68,10 @@
       }],
     },
     reasonableAdjustments: {
+      dateRange: [{
+        summary: 'Select which dates you want to search',
+        details: 'Select which dates you want to search',
+      }],
       dateFrom: [{
         summary: 'Enter a date to search reasonable adjustments from',
         details: 'Enter a date to search reasonable adjustments from',
@@ -195,14 +199,68 @@
     },
     juryExpenditureLowLevel: {
       dateFrom: [{
-        summary: 'Enter a date to search from',
-        details: 'Enter a date to search from',
+        summary: 'Enter a date to search approved expenses from',
+        details: 'Enter a date to search approved expenses from',
       }],
       dateTo: [{
-        summary: 'Enter a date to search up until',
-        details: 'Enter a date to search up until',
+        summary: 'Enter a date to search approved expenses up until',
+        details: 'Enter a date to search approved expenses up until',
       }],
-    }
+    },
+    juryExpenditureHighLevel: {
+      dateFrom: [{
+        summary: 'Enter a date to search approved expenses from',
+        details: 'Enter a date to search approved expenses from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search approved expenses up until',
+        details: 'Enter a date to search approved expenses up until',
+      }],
+    },
+    juryExpenditureMidLevel: {
+      dateFrom: [{
+        summary: 'Enter a date to search approved expenses from',
+        details: 'Enter a date to search approved expenses from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search approved expenses up until',
+        details: 'Enter a date to search approved expenses up until',
+      }],
+    },
+    trialStatistics: {
+      dateFrom: [{
+        summary: 'Enter a date to search trial statistics from',
+        details: 'Enter a date to search trial statistics from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search trial statistics up until',
+        details: 'Enter a date to search trial statistics up until',
+      }],
+    },
+    poolAnalysis: {
+      dateFrom: [{
+        summary: 'Enter a date to analyse pools from',
+        details: 'Enter a date to analyse pools from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to analyse pools up until',
+        details: 'Enter a date to analyse pools up until',
+      }],
+    },
+    completionOfService: {
+      dateRange: [{
+        summary: 'Select which dates you want to search',
+        details: 'Select which dates you want to search',
+      }],
+      dateFrom: [{
+        summary: 'Enter a date to search completion of service from',
+        details: 'Enter a date to search completion of service from',
+      }],
+      dateTo: [{
+        summary: 'Enter a date to search completion of service up until',
+        details: 'Enter a date to search completion of service up until',
+      }],
+    },
   };
 
   module.exports.searchBy = function(reportKey) {
@@ -240,6 +298,16 @@
     };
   };
 
+  module.exports.fixedDateRange = function(reportKey) {
+    return {
+      dateRange: {
+        reportsFixedDateRange: {
+          messageKey: reportKey,
+        },
+      }
+    }
+  }
+
   validate.validators.reportSearchBy = function(value, options, key, attributes) {
     if (typeof value === 'undefined' || value === '') {
       return messageMatrix[options.messageKey].searchBy;
@@ -271,6 +339,12 @@
       }];
     };
     return null;
+  };
+
+  validate.validators.reportsFixedDateRange = function(value, options, key, attributes) {
+    if (typeof value === 'undefined' || value === '') {
+      return messageMatrix[options.messageKey].dateRange;
+    }
   };
 
 })();

--- a/server/routes/reporting/standard-report/standard-report.controller.js
+++ b/server/routes/reporting/standard-report/standard-report.controller.js
@@ -720,6 +720,17 @@
       return res.redirect(addURLQueryParams(reportType, app.namedRoutes.build(`reports.${reportKey}.report.get`, { filter: 'courts' })));
     }
     if (reportType.search === 'dateRange' || reportType.search === 'fixedDateRange') {
+      let validatorResult;
+      
+      if (reportType.search === 'fixedDateRange') {
+        validatorResult = validate(req.body, searchValidator.fixedDateRange(_.camelCase(reportKey), req.body));
+        if (typeof validatorResult !== 'undefined') {
+          req.session.errors = validatorResult;
+          req.session.formFields = req.body;
+          return res.redirect(app.namedRoutes.build(`reports.${reportKey}.filter.get`));
+        }
+      }
+
       if (req.body.dateRange && req.body.dateRange === 'NEXT_31_DAYS') {
         req.body.dateFrom = moment().format('DD/MM/YYYY');
         req.body.dateTo = moment().add(31, 'days').format('DD/MM/YYYY');
@@ -729,7 +740,7 @@
         req.body.dateTo = moment().format('DD/MM/YYYY');
       }
 
-      const validatorResult = validate(req.body, searchValidator.dateRange(_.camelCase(reportKey), req.body));
+      validatorResult = validate(req.body, searchValidator.dateRange(_.camelCase(reportKey), req.body));
       if (typeof validatorResult !== 'undefined') {
         req.session.errors = validatorResult;
         req.session.formFields = req.body;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7997)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=700)


### Change description ###
It does not crash on all of them, but I have identified some reports that do not have correct validation in place.

* {{unconfirmedAttendance}}
* all jury-expenditure levels

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
