### PR TITLE
Replace request-promise with axios on get expenses for approval and approving expenses

### DIFF
--- a/server/routes/juror-management/approve-expenses/approve-expenses.controller.js
+++ b/server/routes/juror-management/approve-expenses/approve-expenses.controller.js
@@ -43,15 +43,12 @@
       delete req.session.fromFields;
 
       try {
-        let { response: data, headers } = await approveExpensesDAO.get(
-          app,
+        let data = await approveExpensesDAO.get(
           req,
           locCode,
           currentTab,
-          dateFilters
+          dateFilters,
         );
-
-        req.session.approveExpensesEtag = headers.etag;
 
         app.logger.info('Fetched expenses awaiting approval: ', {
           auth: req.session.authentication,
@@ -97,8 +94,6 @@
           token: req.session.authToken,
           error: typeof err.error !== 'undefined' ? err.error : err.toString(),
         });
-
-        console.log(err);
 
         return res.render('_errors/generic.njk');
       };
@@ -251,7 +246,10 @@
     replaceAllObjKeys(payload, _.snakeCase);
 
     try {
-      const financialNumbers = await approveExpensesDAO.post(app, req, locCode, currentTab, payload);
+      const response = await approveExpensesDAO.post(req, locCode, currentTab, payload);
+      delete response._headers;
+
+      const financialNumbers = Object.values(response).map((financialNumber) => financialNumber).join(',');
 
       req.session.bannerMessage = `Expenses approved for ${checkedJurors.length > 1
         ? `${checkedJurors.length} jurors`


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7999)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=701)


### Change description ###
We are seeing a number of fails with an {{ECONNRESET}} error on some api calls.

These seem to only happen on calls that use the {{request-promise}} (http requests helper) package and so we thought it would be good to update to the more up-to-date {{axios}} package (also used in the application) to see if the issue still happens.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
