### PR TITLE
INC2554492 - Trial numbers incomplete or missing on Juror history

### DIFF
--- a/server/components/filters/index.js
+++ b/server/components/filters/index.js
@@ -523,18 +523,18 @@
         return copy;
       }
 
-      let parts = copy?.split(/([A-Z][0-9]+)/g);
+      let parts = copy?.split(/( [A-Z][0-9]+)/g);
       
       parts = parts?.map((item) => {
-        if (item.match(/[A-Z][0-9]+/)) {
-          if (item.startsWith('F')) {
-            return `<a href="/reports/financial-audit/${item}" target="_blank">${item}</a>`;
+        if (item.match(/ [A-Z][0-9]+/)) {
+          if (item.startsWith(' F')) {
+            return ` <a href="/reports/financial-audit/${item.trim()}" target="_blank">${item.trim()}</a>`;
           }
-          if (item.startsWith('P')) {
-            return `<a href="/reporting/pool-attendance-audit/report/${item}/print" target="_blank">${item}</a>`;
+          if (item.startsWith(' P')) {
+            return ` <a href="/reporting/pool-attendance-audit/report/${item.trim()}/print" target="_blank">${item.trim()}</a>`;
           }
-          if (item.startsWith('J')) {
-            return `<a href="/reporting/jury-attendance-audit/report/${item}/print" target="_blank">${item}</a>`;
+          if (item.startsWith(' J')) {
+            return ` <a href="/reporting/jury-attendance-audit/report/${item.trim()}/print" target="_blank">${item.trim()}</a>`;
           }
         }
         


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8038)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=713)


### Change description ###
When trying to find out which trial a juror was in the Trial number is not showing up on History.
example juror 344506279 - only the first three number 34S are showing - the trial number should be 43SP0054123
This is happening with multiple jurors not just the above.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
