### PR TITLE
INC2536487 - When reprinting reminders, the user get a error message - unable to reprint for selected jurors [HMCTS Ref INC5634218]

### DIFF
--- a/server/routes/documents/letters-list/letters-list.controller.js
+++ b/server/routes/documents/letters-list/letters-list.controller.js
@@ -143,7 +143,7 @@
 
       checkedJurors.forEach((juror) => {
         if (juror['date_printed'] === 'null') {
-          juror['date_printed'] = dateFilter(new Date(), null, 'YYYY-MM-DD');
+          juror['date_printed'] = null;
         }
       });
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8055)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=721)


### Change description ###
INC2536487 - When reprinting reminders, the user get a error message - unable to reprint for selected jurors [HMCTS Ref INC5634218]



When reprinting reminders, the user get a error message - “Unable to reprint letters for the selected jurors”.

It is happening when trying to select all Juror records in a pool (451240901) and then send out a reminder letter. 
Error in the log:

{"timestamp":"2024-07-30 10:40:01","message":"*eq(null) is not allowed. Use isNull() instead*"}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
