### PR TITLE
Hide the "next due at court date" for deferred jurors to aviod confusion with this date. 

### DIFF
--- a/client/templates/juror-management/_partials/heading.njk
+++ b/client/templates/juror-management/_partials/heading.njk
@@ -86,7 +86,12 @@
         {% endif %}
       </div>
       <div class="govuk-grid-column-one-half govuk-!-padding-2">
-        {% if jurorStatus !== "Postponed" %}
+        {% if jurorStatus === "Deferred" %}
+            <div class="govuk-grid-column-one-third">
+                <div id="courtDeferredDateLabel" class="label info">Deferred to</div>
+                <span id="courtDeferredDate" class="info">{{ juror.commonDetails.deferredTo | dateFilter('yyyy-MM-DD', "ddd D MMM YYYY") }}</span>
+            </div>
+        {% elif jurorStatus !== "Postponed" %}
           <div class="govuk-grid-column-one-third">
             <div id="courtStartDateLabel" class="label info">Service start date</div>
             <span id="courtStartDate" class="info">{{ startDate }}</span>

--- a/client/templates/juror-management/juror-record/attendance.njk
+++ b/client/templates/juror-management/juror-record/attendance.njk
@@ -74,7 +74,7 @@
                 }
               ]
             } if isCourtUser and juror.commonDetails.jurorStatus === "Responded" and juror.commonDetails.loc_code === authentication.locCode
-          },
+          } if juror.commonDetails.jurorStatus !== "Deferred",
           {
             key: {
               text: "Attendances"

--- a/client/templates/juror-management/juror-record/overview.njk
+++ b/client/templates/juror-management/juror-record/overview.njk
@@ -158,7 +158,7 @@
                 } if isCourtUser
               ]
             }
-          },
+          } if juror.commonDetails.jurorStatus !== 'Deferred',
           {
             key: {
               text: "Checked in today"


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8068)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=732)


### Change description ###
I have deferred a juror to June next year, however, the next due at court still showing Monday next week. He still showing up on my attendance list for Monday. (SCREENSHOTS IN TEAMS CHAT) I have manually changed the 'next due at court date' but this still need fixing

Hide the "next due at court date" for deferred jurors to avoid confusion with this date. Ticket needed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
