### PR TITLE
Returning a jury without check out time can leave jurors in limbo

### DIFF
--- a/client/templates/juror-management/attendance.njk
+++ b/client/templates/juror-management/attendance.njk
@@ -5,6 +5,7 @@
 {% from "custom-components/macros/arrows.njk" import leftArrowSVG %}
 {% from "./_partials/attendance-sub-nav.njk" import attendanceSubNav %}
 {% from "moj/components/button-menu/macro.njk" import mojButtonMenu %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% block page_title %}{{ serviceName }} - Juror management - Attendance{% endblock %}
 {% block page_identifier %}Juror management - Attendance{% endblock %}
@@ -21,7 +22,15 @@
   {% if tmpFields !== undefined %}
     {% include "includes/errors.njk" %}
   {% endif %}
-
+ {% if previousDayIsConfirmed == false and attendanceStatus !== "Confirmed" %}
+     <div class="govuk-grid-column-full">
+      {{ mojBanner({
+        type: "information",
+        text: yesterday + " has not been confirmed yet, confirm that days attendance before checking in jurors for today",
+        iconFallbackText: "information"
+      }) }}
+      </div>
+ {% endif %}
   <div class="govuk-error-summary js-hidden" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <p class="govuk-error-summary__title" id="error-summary-title">
       There is a problem
@@ -43,6 +52,7 @@
       <span class="govuk-caption-l">Jurors in waiting</span>
       <h1 class="govuk-heading-l" id="attendanceDate">{{ selectedDate }}</h1>
     </div>
+
     <div class="govuk-grid-column-one-half">
       <div class="govuk-button-group mod-flex mod-justify-end">
         <div class="moj-button-menu">

--- a/client/templates/juror-management/attendance.njk
+++ b/client/templates/juror-management/attendance.njk
@@ -22,11 +22,11 @@
   {% if tmpFields !== undefined %}
     {% include "includes/errors.njk" %}
   {% endif %}
- {% if previousDayIsConfirmed == false and attendanceStatus !== "Confirmed" %}
+ {% if previousWorkingDayIsConfirmed == false and attendanceStatus !== "Confirmed" %}
      <div class="govuk-grid-column-full">
       {{ mojBanner({
         type: "information",
-        text: yesterday + " has not been confirmed yet, confirm that days attendance before checking in jurors for today",
+        text: previousWorkingDay + " has not been confirmed yet, confirm that days attendance before checking in jurors for today",
         iconFallbackText: "information"
       }) }}
       </div>

--- a/client/templates/trial-management/returns/return-attendance.njk
+++ b/client/templates/trial-management/returns/return-attendance.njk
@@ -29,7 +29,7 @@
           value: prevAnswer,
           items: [
             { value: 'confirm', text: 'Return and confirm attendance' },
-            { value: 'return', text: 'Return but do not confirm attendance'},
+            { value: 'return', text: 'Return but do not confirm attendance'} if dayIsConfirmed == false,
             { value: 'complete', text: 'Return, confirm attendance and complete their service' }
           ]})
         }}

--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -6,6 +6,28 @@
   const dateFilter = require('../../components/filters').dateFilter;
   const { jurorsAttending, poolAttedanceAuditDAO } = require('../../objects/juror-attendance');
 
+  module.exports.isAttendanceConfirmed = async function(app, req, locCode, attendanceDate) {
+      return isAttendanceConfirmedByAttendances(await getAppearances(app,req, locCode, attendanceDate));
+  }
+
+  async function getAppearances(app, req, locCode, attendanceDate) {
+    const group = 'IN_WAITING';
+    let { 'juror_appearance_response_data': attendees } = await jurorsAttending.get(
+      require('request-promise'),
+      app,
+      req.session.authToken,
+      locCode,
+      attendanceDate,
+      group
+    );
+    attendees = attendees.map((attendee) => {
+        attendee['juror_status'] = getJurorStatus(attendee['juror_status']);
+        return _.mapKeys(attendee, (__, key) => _.camelCase(key));
+    });
+
+    return typeof attendees !== 'undefined' ? attendees : [];
+  }
+
   module.exports.getAttendance = function(app) {
     return async function(req, res) {
       const { status } = req.params;
@@ -19,25 +41,13 @@
 
       const selectedDate = date ? new Date(date) : new Date();
       const selectedDateString = dateFilter(selectedDate, null, 'YYYY-MM-DD');
-      const group = 'IN_WAITING';
 
       const confirmedTab = tab || 'attended';
 
       try {
-        let { 'juror_appearance_response_data': attendees } = await jurorsAttending.get(
-          require('request-promise'),
-          app,
-          req.session.authToken,
-          req.session.authentication.locCode,
-          selectedDateString,
-          group
-        );
 
-        attendees = attendees.map((attendee) => {
-          attendee['juror_status'] = getJurorStatus(attendee['juror_status']);
-          return _.mapKeys(attendee, (__, key) => _.camelCase(key));
-        });
-        req.session.dailyAttendanceList = typeof attendees !== 'undefined' ? attendees : [];
+        const attendees = await getAppearances(app,req, req.session.authentication.locCode, selectedDateString);
+        req.session.dailyAttendanceList = attendees;
         req.session.attendanceListDate = selectedDateString;
 
         const listedJurors = req.session.dailyAttendanceList.filter(attendee => attendee.checkInTime !== null);
@@ -59,7 +69,7 @@
         );
         // TODO: until here
 
-        const attendanceConfirmed = isAttendanceConfirmed(attendees);
+        const attendanceConfirmed = isAttendanceConfirmedByAttendances(attendees);
 
         req.session.preReportRoute = app.namedRoutes.build('juror-management.attendance.get')
           + `?date=${date || dateFilter(new Date(), null, 'yyyy-MM-DD')}`;
@@ -124,7 +134,7 @@
     };
   };
 
-  function isAttendanceConfirmed(attendees) {
+  function isAttendanceConfirmedByAttendances(attendees) {
     if (!attendees.length) return false;
 
     return attendees.filter(attendee => attendee.appearanceConfirmed).length > 0;

--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -2,7 +2,7 @@
   'use strict';
 
   const _ = require('lodash');
-  const { getJurorStatus } = require('../../lib/mod-utils');
+  const { getJurorStatus, setPreviousWorkingDay } = require('../../lib/mod-utils');
   const dateFilter = require('../../components/filters').dateFilter;
   const { jurorsAttending, poolAttedanceAuditDAO } = require('../../objects/juror-attendance');
 
@@ -42,12 +42,13 @@
       const selectedDate = date ? new Date(date) : new Date();
       const selectedDateString = dateFilter(selectedDate, null, 'YYYY-MM-DD');
 
-      const yesterday = new Date().setDate(selectedDate.getDate() - 1);
-
       const confirmedTab = tab || 'attended';
 
       try {
-        const previousDayIsConfirmed = isAttendanceConfirmedByAttendances(await getAppearances(app, req, req.session.authentication.locCode, dateFilter(yesterday, null, 'YYYY-MM-DD')));
+        const yesterday = new Date();
+        yesterday.setDate(selectedDate.getDate() - 1);
+        const previousWorkingDay = setPreviousWorkingDay(new Date(selectedDate));
+        const previousWorkingDayIsConfirmed = isAttendanceConfirmedByAttendances(await getAppearances(app, req, req.session.authentication.locCode, dateFilter(previousWorkingDay, null, 'YYYY-MM-DD')));
 
         const attendees = await getAppearances(app,req, req.session.authentication.locCode, selectedDateString);
         req.session.dailyAttendanceList = attendees;
@@ -100,7 +101,8 @@
           selectedDate: dateFilter(selectedDate, null, dateFormat),
           yesterday: dateFilter(yesterday, null, dateFormat),
           yesterdayRaw: dateFilter(yesterday, null, 'YYYY-MM-DD'),
-          previousDayIsConfirmed: previousDayIsConfirmed,
+          previousWorkingDay: dateFilter(previousWorkingDay, null, dateFormat),
+          previousWorkingDayIsConfirmed: previousWorkingDayIsConfirmed,
           listedJurors,
           confirmedJurors,
           absentJurors,

--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -42,9 +42,12 @@
       const selectedDate = date ? new Date(date) : new Date();
       const selectedDateString = dateFilter(selectedDate, null, 'YYYY-MM-DD');
 
+      const yesterday = new Date().setDate(selectedDate.getDate() - 1);
+
       const confirmedTab = tab || 'attended';
 
       try {
+        const previousDayIsConfirmed = isAttendanceConfirmedByAttendances(await getAppearances(app, req, req.session.authentication.locCode, dateFilter(yesterday, null, 'YYYY-MM-DD')));
 
         const attendees = await getAppearances(app,req, req.session.authentication.locCode, selectedDateString);
         req.session.dailyAttendanceList = attendees;
@@ -95,8 +98,9 @@
           attendanceStatus: attendanceConfirmed ? 'Confirmed' : 'Unconfirmed',
           confirmedTab,
           selectedDate: dateFilter(selectedDate, null, dateFormat),
-          yesterday: dateFilter(selectedDate.setDate(selectedDate.getDate() - 1), null, dateFormat),
-          yesterdayRaw: dateFilter(selectedDate, null, 'YYYY-MM-DD'),
+          yesterday: dateFilter(yesterday, null, dateFormat),
+          yesterdayRaw: dateFilter(yesterday, null, 'YYYY-MM-DD'),
+          previousDayIsConfirmed: previousDayIsConfirmed,
           listedJurors,
           confirmedJurors,
           absentJurors,

--- a/server/routes/trial-management/returns.controller.js
+++ b/server/routes/trial-management/returns.controller.js
@@ -78,8 +78,7 @@
     }));
   };
 
-  module.exports.getReturnAttendance = (app) => function(app) {
-  return async function(req, res) {
+  module.exports.getReturnAttendance = (app) => async (req, res) => {
     const { trialNumber, locationCode } = req.params;
     const tmpErrors = _.clone(req.session.errors);
 

--- a/server/routes/trial-management/returns.controller.js
+++ b/server/routes/trial-management/returns.controller.js
@@ -79,24 +79,27 @@
   };
 
   module.exports.getReturnAttendance = (app) => async (req, res) => {
-      const { trialNumber, locationCode } = req.params;
-      const tmpErrors = _.clone(req.session.errors);
+    const { trialNumber, locationCode } = req.params;
+    const tmpErrors = _.clone(req.session.errors);
 
-      delete req.session.errors;
-      delete req.session[`${trialNumber}-${locationCode}-checkInTime`];
-      delete req.session[`${trialNumber}-${locationCode}-checkOutTime`];
-      const dayIsConfirmed;
-      try {
+    delete req.session.errors;
+    delete req.session[`${trialNumber}-${locationCode}-checkInTime`];
+    delete req.session[`${trialNumber}-${locationCode}-checkOutTime`];
+    let dayIsConfirmed;
+
+    try {
       dayIsConfirmed = await isAttendanceConfirmed(app, req, req.params.locationCode, dateFilter(new Date(), null, 'YYYY-MM-DD'));
-     } catch(err) {
-        app.logger.crit('Failed to check if day is confirmed ', {
-          auth: req.session.authentication,
-          data: {
-            locCode: req.params.locationCode
-            attendanceDate: dateFilter(new Date(), null, 'YYYY-MM-DD'),
-          },
-          error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
-        });
+    } catch(err) {
+      app.logger.crit('Failed to check if day is confirmed ', {
+        auth: req.session.authentication,
+        data: {
+          locationCode,
+          trialNumber,
+          attendanceDate: dateFilter(new Date(), null, 'YYYY-MM-DD'),
+        },
+        error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
+      });
+  
       return res.render('_errors/generic.njk');
     }
     return res.render('trial-management/returns/return-attendance.njk', {
@@ -117,7 +120,7 @@
         items: tmpErrors,
       },
       prevAnswer: req.session[`${trialNumber}-${locationCode}-handleAttendance`],
-      dayIsConfirmed: dayIsConfirmed
+      dayIsConfirmed: dayIsConfirmed,
     });
   };
 

--- a/server/routes/trial-management/returns.controller.js
+++ b/server/routes/trial-management/returns.controller.js
@@ -9,6 +9,7 @@
   const { convert12to24, dateFilter, convertAmPmToLong } = require('../../components/filters');
   const { padTimeForApi } = require('../../lib/mod-utils');
   const { panelListDAO, trialDetailsObject } = require('../../objects');
+  const isAttendanceConfirmed = require('../juror-management/juror-management.controller').isAttendanceConfirmed;
 
 
   module.exports.postReturnJurors = (app) => async (req, res) => {
@@ -77,13 +78,15 @@
     }));
   };
 
-  module.exports.getReturnAttendance = (app) => (req, res) => {
+  module.exports.getReturnAttendance = (app) => function(app) {
+  return async function(req, res) {
     const { trialNumber, locationCode } = req.params;
     const tmpErrors = _.clone(req.session.errors);
 
     delete req.session.errors;
     delete req.session[`${trialNumber}-${locationCode}-checkInTime`];
     delete req.session[`${trialNumber}-${locationCode}-checkOutTime`];
+    const dayIsConfirmed = await isAttendanceConfirmed(app, req, req.params.locationCode, dateFilter(new Date(), null, 'YYYY-MM-DD'));
 
     return res.render('trial-management/returns/return-attendance.njk', {
       formActions: {
@@ -103,6 +106,7 @@
         items: tmpErrors,
       },
       prevAnswer: req.session[`${trialNumber}-${locationCode}-handleAttendance`],
+      dayIsConfirmed: dayIsConfirmed
     });
   };
 

--- a/server/routes/trial-management/returns.controller.js
+++ b/server/routes/trial-management/returns.controller.js
@@ -79,46 +79,46 @@
   };
 
   module.exports.getReturnAttendance = (app) => async (req, res) => {
-  try{
       const { trialNumber, locationCode } = req.params;
       const tmpErrors = _.clone(req.session.errors);
 
       delete req.session.errors;
       delete req.session[`${trialNumber}-${locationCode}-checkInTime`];
       delete req.session[`${trialNumber}-${locationCode}-checkOutTime`];
-      const dayIsConfirmed = await isAttendanceConfirmed(app, req, req.params.locationCode, dateFilter(new Date(), null, 'YYYY-MM-DD'));
-
-      return res.render('trial-management/returns/return-attendance.njk', {
-        formActions: {
-          returnUrl: app.namedRoutes.build('trial-management.trials.return.check-out.get', {
-            trialNumber,
-            locationCode,
-          }),
-        },
-        selectedJurors: req.session[`${trialNumber}-${locationCode}-returnJurors`],
-        cancelUrl: app.namedRoutes.build('trial-management.trials.detail.get', {
-          trialNumber,
-          locationCode,
-        }),
-        errors: {
-          title: 'Please check the form',
-          count: typeof tmpErrors !== 'undefined' ? Object.keys(tmpErrors).length : 0,
-          items: tmpErrors,
-        },
-        prevAnswer: req.session[`${trialNumber}-${locationCode}-handleAttendance`],
-        dayIsConfirmed: dayIsConfirmed
-      });
-    } catch(err) {
-        app.logger.crit('Failed to get return attendances: ', {
+      const dayIsConfirmed;
+      try {
+      dayIsConfirmed = await isAttendanceConfirmed(app, req, req.params.locationCode, dateFilter(new Date(), null, 'YYYY-MM-DD'));
+     } catch(err) {
+        app.logger.crit('Failed to check if day is confirmed ', {
           auth: req.session.authentication,
           data: {
-            locCode: locCode
-            attendanceDate: attendanceDate,
+            locCode: req.params.locationCode
+            attendanceDate: dateFilter(new Date(), null, 'YYYY-MM-DD'),
           },
           error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
         });
       return res.render('_errors/generic.njk');
     }
+    return res.render('trial-management/returns/return-attendance.njk', {
+      formActions: {
+        returnUrl: app.namedRoutes.build('trial-management.trials.return.check-out.get', {
+          trialNumber,
+          locationCode,
+        }),
+      },
+      selectedJurors: req.session[`${trialNumber}-${locationCode}-returnJurors`],
+      cancelUrl: app.namedRoutes.build('trial-management.trials.detail.get', {
+        trialNumber,
+        locationCode,
+      }),
+      errors: {
+        title: 'Please check the form',
+        count: typeof tmpErrors !== 'undefined' ? Object.keys(tmpErrors).length : 0,
+        items: tmpErrors,
+      },
+      prevAnswer: req.session[`${trialNumber}-${locationCode}-handleAttendance`],
+      dayIsConfirmed: dayIsConfirmed
+    });
   };
 
   module.exports.postReturnAttendance = (app) => (req, res) => {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7967)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=733)


### Change description ###
Steps to replicate:

* some jurors are on a trial for the day
* some jurors are in waiting for the day
* confirm attendance for one or more checked in jurors in waiting
* return the jury without setting a check out time

as a result, the jurors returned from the trial will not be visible/available to add expenses

N.B. setting the appearance_confirmed flag for the returned jurors would not resolve the issue

agreed fix for this is the following:

* Display a message when a previous day has not been confirmed to prompt users to confirm that day before checking jurors in and empanelling them as this will drop them off yesterday list as they are now in juror status. ‘Wednesday the 14th of August (example date) has not been confirmed yet, confirm that days attendance before checking in jurors for today’
* when a day has been confirmed you can not return a jury back to jurors in waiting we will hide those options you will only be able to return then and confirm their attendance for the day

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
