### PR TITLE
hotfix/JM-8082: Edit user button not showing in "Court Administration" section of the application

### DIFF
--- a/client/templates/administration/users/user-record.njk
+++ b/client/templates/administration/users/user-record.njk
@@ -52,7 +52,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-top-3 govuk-!-margin-bottom-3">{{ user.name }}</h1>
     </div>
 
-    {% if not isSJO and user.email !== authentication.email %}
+    {% if (isManager or isSystemAdministrator) and user.email !== authentication.email %}
       <div class="govuk-grid-column-one-half mod-flex mod-justify-end">
         {{ govukButton({
           text: "Edit user",

--- a/server/routes/administration/users/edit-user/edit-user.controller.js
+++ b/server/routes/administration/users/edit-user/edit-user.controller.js
@@ -3,7 +3,7 @@
 
   const _ = require('lodash');
   const { validate } = require('validate.js');
-  const { isSJOUser } = require('../../../../components/auth/user-type');
+  const { isSJOUser, isManager } = require('../../../../components/auth/user-type');
   const validator = require('../../../../config/validation/create-users');
   const { usersDAO } = require('../../../../objects/users');
   const { replaceAllObjKeys, makeManualError } = require('../../../../lib/mod-utils');
@@ -19,7 +19,7 @@
       delete req.session.errors;
       delete req.session.editUser;
 
-      if (isSJOUser(req)) {
+      if (isSJOUser(req) && !isManager(req)) {
         app.logger.warn('SJO user tried to edit user details', {
           auth: req.session.authentication,
           data: {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-8082

### Change description ###

Updated edit user permission in template to check for manager role or system admin. 
Aligning with the types of users that can edit user details.
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>

User Type | Can edit user?
-- | --
Administrator | Yes
Court User Standard | No
Court Manager | Yes
Court SJO | No
Court Manager & SJO | Yes
Bureau User Standard | No
Bureau Manager | Yes


</body>
</html>


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
