### PR TITLE
Third party details in the juror record does not save the details

### DIFF
--- a/client/templates/juror-management/_partials/third-party-details.njk
+++ b/client/templates/juror-management/_partials/third-party-details.njk
@@ -1,5 +1,16 @@
 {% set thirdPartyNameParts = [juror.thirdParty.thirdPartyFName, juror.thirdParty.thirdPartyLName] | join(" ") %}
 
+{% set thirdPartyReason = "-" %}
+
+{% if juror.thirdParty.thirdPartyReason and juror.thirdParty.thirdPartyOtherReason %}
+    {% set thirdPartyReason = juror.thirdParty.thirdPartyReason + " - " + juror.thirdParty.thirdPartyOtherReason %}
+{% elif juror.thirdParty.thirdPartyReason %}
+    {% set thirdPartyReason = juror.thirdParty.thirdPartyReason %}
+{% elif juror.thirdParty.thirdPartyOtherReason %}
+    {% set thirdPartyReason = juror.thirdParty.thirdPartyOtherReason %}
+{% endif %}
+
+
 <div class="mod-juror-record__title govuk-body">
   <h2 id="jurorDetailsLabel" class="govuk-heading-m">Third party details</h2>
 </div>
@@ -29,7 +40,7 @@
             text: "Reason for completing"
           },
           value: {
-            text: juror.thirdParty.thirdPartyReason or "-"
+            text: thirdPartyReason
           }
         },
         {

--- a/client/templates/response/_partials/juror-details.njk
+++ b/client/templates/response/_partials/juror-details.njk
@@ -273,14 +273,6 @@
               {{ thirdPartyDetails.mainPhone }}
             </dd>
           </div>
-          <div class="govuk-summary-list__row info" id="thirdPartyMainPhoneRow">
-            <dt class="govuk-summary-list__key">
-              {{ "Main phone" if hasModAccess else "Third party primary phone" }}
-            </dt>
-            <dd class="govuk-summary-list__value" id="thirdPartyMainPhone">
-              {{ thirdPartyDetails.mainPhone }}
-            </dd>
-          </div>
           <div class="govuk-summary-list__row info" id="thirdPartyOtherPhoneRow">
             <dt class="govuk-summary-list__key">
               {{ "Another phone" if hasModAccess else "Third party secondary phone" }}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8053)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=745)


### Change description ###
When updating the third party details from the juror record the option is there but it will not save the changes even when save is selected in the application.

[~accountid:62306f3e50cceb0070797d12]  a design change is required to this section to allow the user to select how the juror should be contacted i.e contact via third party or contact via juror details.

We will need to update the edit juror details API to support the third party details section.
Add a new table for juror_third_party
Update the get juror details API to include third party details
Update the FE to send / load in this new data

Update digital and paper response processing to copy the response third party details onto the new table

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
