### PR TITLE
hotfix/JM-8098:  Flag marked showing incorrectly on straight through responses and reasonable adjustment responses.

### DIFF
--- a/client/templates/summons-management/_common/details-banner-new.njk
+++ b/client/templates/summons-management/_common/details-banner-new.njk
@@ -6,15 +6,11 @@
   {% set serviceStartDate = response.hearingDate | dateFilter("DD/MM/YYYY", "ddd DD MMM YYYY") %}
 {% endif %}
 
-{% if (response.statusRender) === "Responded" and (response.deferral != null or response.excusal != null) %}
+{% if (response.statusRender) === "Responded" and response.excusal %}
   {% set title = "" %}
 
   {% if replyType === "EXCUSAL" %}
     {% set title = "Excusal refused" %}
-  {% endif %}
-
-  {% if replyType === "DEFERRAL" %}
-    {% set title = "Deferral refused" %}
   {% endif %}
 
   {% set iconHtml %}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-8098

### Change description ###

Updated summons reply warning sign to only show for refused excusal.
2nd deferral refusal warning should only show on juror record (which it currently does)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
