### PR TITLE
Warning icon missing from records that should display

### DIFF
--- a/server/routes/response/detail/detail.controller.js
+++ b/server/routes/response/detail/detail.controller.js
@@ -2567,6 +2567,7 @@
 
     if (responseData.excusalReason){
       isExcusal = true;
+      responseData.excusal = true;
 
       if (hasModAccess && responseData.excusalReason === 'D') {
         isDeceased = true;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8101)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=749)


### Change description ###
Warning icon missing from records that should display

Ref (JM-8039) is also not fully fixed. I spoke to Ben about it before he joined your call but we only had a few minutes. You might need to check in with Ben on that but the flag is incorrectly applying to the wrong responses. (It is working on the ones it should as well) its just that additional incorrect bit we need to fix. 

h3. Icon display:

|| ||*Deferral refused*||*Excusal refused*||
|Summons digital|No|Yes|
|Summons paper|No|Yes|
|Juror record|Yes|Yes|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
