### PR TITLE
hotfix/JM-8111: Internal server error when clicking Back link after age disqualification

### DIFF
--- a/server/lib/back-link.js
+++ b/server/lib/back-link.js
@@ -20,7 +20,8 @@ const bypassUrls = [
   '/paper/excusal',
   '/digital/disqualify',
   '/paper/disqualify',
-  /\/juror-management\/record\/\d{9}\/details\/.*/,
+  '/details/edit',
+  '/details/ineligible-age'
 ];
 
 function resolveBackLink(req) {
@@ -65,12 +66,7 @@ function isUrlWhitelisted(url) {
 }
 
 function isBypassUrl(url) {
-  return bypassUrls.some(bypassUrl => {
-    if (bypassUrl instanceof RegExp) {
-      return bypassUrl.test(url);
-    }
-    return url.includes(bypassUrl);
-  })
+  return bypassUrls.some(bypassUrl => url.includes(bypassUrl));
 }
 
 function isAssetUrl(url) {

--- a/server/lib/back-link.js
+++ b/server/lib/back-link.js
@@ -20,6 +20,7 @@ const bypassUrls = [
   '/paper/excusal',
   '/digital/disqualify',
   '/paper/disqualify',
+  /\/juror-management\/record\/\d{9}\/details\/.*/,
 ];
 
 function resolveBackLink(req) {
@@ -36,7 +37,7 @@ function resolveBackLink(req) {
   }
   
   if (!req.session.historyStack || req.session.historyStack.length === 0) {
-    // the history stack keeps all the "curren" pages visited
+    // the history stack keeps all the "current" pages visited
     // this way we will be able to identify a refresh or a back-link click....
     // refresh should match historyStack[0] and back-link should match historyStack[1]
     // if it is a refresh we keep the stack normal and if it is a back-link click we need to pop 2 (?) elements
@@ -64,7 +65,12 @@ function isUrlWhitelisted(url) {
 }
 
 function isBypassUrl(url) {
-  return bypassUrls.some(bypassUrl => url.includes(bypassUrl));
+  return bypassUrls.some(bypassUrl => {
+    if (bypassUrl instanceof RegExp) {
+      return bypassUrl.test(url);
+    }
+    return url.includes(bypassUrl);
+  })
 }
 
 function isAssetUrl(url) {

--- a/server/lib/back-link.js
+++ b/server/lib/back-link.js
@@ -21,7 +21,8 @@ const bypassUrls = [
   '/digital/disqualify',
   '/paper/disqualify',
   '/details/edit',
-  '/details/ineligible-age'
+  '/details/ineligible-age',
+  '/multiple-tabs',
 ];
 
 function resolveBackLink(req) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-8111

### Change description ###

Updated dynamic back link bypass urls to also accept RegExp.
Added juror management edit details flow to bypass urls to avoid data issues.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
