### PR TITLE
The persons attending details and summery to add an option to include panel/juror status jurors

### DIFF
--- a/client/templates/reporting/persons-attending/attendance-date.njk
+++ b/client/templates/reporting/persons-attending/attendance-date.njk
@@ -70,15 +70,19 @@
           errorMessage: searchByError
         }) }}
         {{ govukCheckboxes({
-          name: "includeSummoned",
+          name: "optionsToInclude",
           classes: "govuk-checkboxes--small",
           items: [
             {
-              value: true,
+              value: "includeSummoned",
               text: "Include jurors with summoned status"
+            },
+            {
+              value: "includePanelMembers",
+              text: "Include jurors with panel or juror status"
             }
           ],
-          values: tmpBody.includeSummoned
+          values: tmpBody.optionsToInclude
         }) }}
         {{ csrfProtection(csrftoken) }}
         <div class="govuk-button-group">

--- a/server/routes/reporting/persons-attending/persons-attending-controller.js
+++ b/server/routes/reporting/persons-attending/persons-attending-controller.js
@@ -6,6 +6,7 @@
   const { validate } = require('validate.js');
   const validator = require('../../../config/validation/report-search-by');
   const { dateFilter } = require('../../../components/filters');
+  const { checkConvertArray } = require('../../../lib/mod-utils');
 
   module.exports.getFilterAttendanceDate = function(app) {
     return function(req, res) {
@@ -51,13 +52,16 @@
         }
       }
 
-      const includeSummoned = req.body.includeSummoned ? `?includeSummoned=${req.body.includeSummoned}` : '';
+      req.body.optionsToInclude = checkConvertArray(req.body.optionsToInclude);
+
+      const includeSummoned = `?includeSummoned=${req.body.optionsToInclude.includes('includeSummoned')}`;
+      const includePanelMembers = `&includePanelMembers=${req.body.optionsToInclude.includes('includePanelMembers')}`;
 
       switch (req.body.searchBy) {
       case 'today':
         return res.redirect(app.namedRoutes.build(`reports.${reportKey}.report.get`, {
           filter: dateFilter(new Date(), null, 'YYYY-MM-DD'),
-        }) + includeSummoned);
+        }) + includeSummoned + includePanelMembers);
       case 'nextWorkingDay':
         const date = new Date();
         const day = date.getDay();
@@ -72,11 +76,11 @@
         date.setDate(date.getDate() + addDays);
         return res.redirect(app.namedRoutes.build(`reports.${reportKey}.report.get`, {
           filter: dateFilter(date, null, 'YYYY-MM-DD'),
-        }) + includeSummoned);
+        }) + includeSummoned + includePanelMembers);
       case 'otherDate':
         return res.redirect(app.namedRoutes.build(`reports.${reportKey}.report.get`, {
           filter: dateFilter(req.body.date, null, 'YYYY-MM-DD'),
-        }) + includeSummoned);
+        }) + includeSummoned + includePanelMembers);
       default:
         return res.redirect(app.namedRoutes.build(`reports.${reportKey}.filter.get`));
       }

--- a/server/routes/reporting/standard-report/definitions.js
+++ b/server/routes/reporting/standard-report/definitions.js
@@ -355,6 +355,7 @@
         search: 'date',
         queryParams: {
           includeSummoned: req?.query?.includeSummoned || false,
+          includePanelMembers: req?.query?.includePanelMembers || false,
         },
         headings: [
           'attendanceDate',
@@ -372,6 +373,7 @@
         search: 'date',
         queryParams: {
           includeSummoned: req?.query?.includeSummoned || false,
+          includePanelMembers: req?.query?.includePanelMembers || false,
         },
         headings: [
           'attendanceDate',

--- a/server/routes/reporting/standard-report/standard-report.controller.js
+++ b/server/routes/reporting/standard-report/standard-report.controller.js
@@ -605,6 +605,7 @@
 
     if (reportKey.includes('persons-attending')) {
       config.includeSummoned = req.query.includeSummoned || false;
+      config.includePanelMembers = req.query.includePanelMembers || false;
     }
     if(req.query.includeJurorsOnCall) {
       config.includeJurorsOnCall = req.query.includeJurorsOnCall;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8135)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=764)


### Change description ###
Currently we include all jurors with a status responded panel and juror by default if they have the right next attendance date. Going forward we need to add a check box (as per the include summoned status) to include panel or juror status jurors and the default is of only responded jurors with the correct next attendance date:



!image-20240823-150358.png|width=1664,height=700,alt="image-20240823-150358.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
