### PR TITLE
hotfix/JM-7949: A juror with a juror_pool status of 2 and response in TODO tries to call a removed endpoint

### DIFF
--- a/server/routes/response/detail/detail.controller.js
+++ b/server/routes/response/detail/detail.controller.js
@@ -162,37 +162,10 @@
           processingStatus = data.processingStatus;
           renderPage = 'detail';
 
-          if (poolStatus && processingStatus === 'TODO'){
-            switch (poolStatus) {
-            case 2:
-              responseCompletedMesssage = 'The juror record has been processed as responded and the summons reply has been completed';
-              renderPage = 'response-completed';
-              break;
-            case 5:
-              responseCompletedMesssage = 'The juror record has been processed as excused or deceased and the summons reply has been completed';
-              renderPage = 'response-completed';
-              break;
-            case 6:
-              responseCompletedMesssage = 'The juror record has been processed as disqualified and the summons reply has been completed';
-              renderPage = 'response-completed';
-              break;
-            case 7:
-              responseCompletedMesssage = 'The juror record has been processed as deferred and the summons reply has been completed';
-              renderPage = 'response-completed';
-              break;
-            case 11:
-              renderPage = 'awaiting-information';
-              req.session.awaitingInformation.required = true;
-              req.session.awaitingInformation.cancelUrl = req.session.sourceUrl;
-              break;
-            default:
-              break;
-            }
-
-            if (responseCompletedMesssage) {
-              req.session['responseCompletedMesssage'] = responseCompletedMesssage;
-            }
-
+          if (poolStatus && processingStatus === 'TODO'  && poolStatus === 11){
+            renderPage = 'awaiting-information';
+            req.session.awaitingInformation.required = true;
+            req.session.awaitingInformation.cancelUrl = req.session.sourceUrl;
           };
 
           if (renderPage === 'awaiting-information'){
@@ -361,48 +334,6 @@
                     isDeceased: data.thirdPartyReason === 'deceased' || data.excusalReason === 'D',
                   });
                 }
-              }
-
-
-              if (renderPage === 'response-completed'){
-                return sendCourtObj.post(
-                  require('request-promise'),
-                  app,
-                  req.session.authToken,
-                  data.jurorNumber,
-                  data.version,
-                )
-                  .then(
-                    (sendCourtResponse, opticReference) => {
-                      app.logger.info('prolcessed response completed: ', {
-                        auth: req.session.authentication,
-                        data: {
-                          jurorNumber: data.jurorNumber,
-                          version: data.version,
-                        },
-                        response: sendCourtResponse,
-                      });
-    
-                      return res.redirect(app.namedRoutes.build('response.detail.get', {id: data.jurorNumber}));
-                        
-                    }
-                  )
-                  .catch(
-                    (err) => {
-    
-                      app.logger.crit('Error processing response completed: ', {
-                        auth: req.session.authentication,
-                        data: {
-                          jurorNumber: data.jurorNumber,
-                          version: data.version,
-                        },
-                        error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
-                      });
-    
-                      return res.redirect(app.namedRoutes.build('response.detail.get', {id: data.jurorNumber}));
-    
-                    }
-                  );
               }
               
               if (req.session.responseCompletedMesssage) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7949

### Change description ###

Removed circular call to an endpoint that no longer exists, when  juror_pool has certain statuses and the response is in TODO. 
In Juror Mod if the juror record is updated to certain statuses prior to summons being processed, the response is closed. This was not the case before and another endpoint was called to close the response, which is no longer in use, causing circular call and crashing app.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
