### PR TITLE
Attendance ordering incorrect on juror history

### DIFF
--- a/client/templates/juror-management/_partials/attendance-tab.njk
+++ b/client/templates/juror-management/_partials/attendance-tab.njk
@@ -51,10 +51,10 @@
           <tbody class="govuk-table__body">
             {% for item in history.paymentDays %}
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ item.attendanceDate | dateFilter('yyyy-MM-DD', 'ddd DD MMM yyyy') }}</td>
+                <td class="govuk-table__cell" data-sort-value="{{item.attendanceDate | dateFilter('yyyy-MM-dd', 'YYYYMMDD')}}">{{ item.attendanceDate | dateFilter('yyyy-MM-DD', 'ddd DD MMM yyyy') }}</td>
                 <td class="govuk-table__cell">{{ item.attendanceAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser, false) | safe }}</td>
                 <td class="govuk-table__cell">{{ (item.paymentAudit | historyAuditLinkify(juror.commonDetails.loc_code, isCourtUser, false) | safe) if item.paymentAudit else '-' }}</td>
-                <td class="govuk-table__cell"> {{ (item.datePaid | dateFilter('yyyy-MM-DD', 'ddd DD MMM yyyy')) if item.datePaid else '-' }}</td>
+                <td class="govuk-table__cell" data-sort-value="{{item.datePaid | dateFilter('yyyy-MM-dd', 'YYYYMMDD')}}"> {{ (item.datePaid | dateFilter('yyyy-MM-DD', 'ddd DD MMM yyyy')) if item.datePaid else '-' }}</td>
                 <td class="govuk-table__cell"> {{ (item.datePaid | convertDateTimeToTime | convert24to12) if item.datePaid else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.travel | toMoney) if (item.travel or item.paymentAudit) else '-' }}</td>
                 <td class="govuk-table__cell">{{ (item.financialLoss | toMoney) if (item.financialLoss or item.paymentAudit) else '-' }}</td>


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8138)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=768)


### Change description ###
As per title. ordering is incorrect. I thought it might be ordering on date entered, but on looking in the DB I dont think that’s it either.

!image-20240827-110514.png|width=1457,height=412,alt="image-20240827-110514.png"!



!image-20240827-110638.png|width=1566,height=223,alt="image-20240827-110638.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
