### PR TITLE
INC2571749 - Juror-record attendance breaks when a time-out is not set

### DIFF
--- a/client/templates/juror-management/juror-record/_partials/attendance-table.njk
+++ b/client/templates/juror-management/juror-record/_partials/attendance-table.njk
@@ -27,10 +27,10 @@
           {% set hours = "-" %}
           {% set travelTime = "-" %}
           {% if day["attendance_type"] !== "ABSENT" and day["attendance_type"] !== "NON_ATTENDANCE" and day["attendance_type"] !== "NON_ATTENDANCE_LONG_TRIAL" %}
-            {% set checkInTime = day["check_in_time"] | timeArrayToString | convert24to12 %}
-            {% set checkOutTime = day["check_out_time"] | timeArrayToString | convert24to12%}
+            {% set checkInTime = (day["check_in_time"] | timeArrayToString | convert24to12) if day["check_in_time"] else "-" %}
+            {% set checkOutTime = (day["check_out_time"] | timeArrayToString | convert24to12) if day["check_out_time"] else "-" %}
             {% set hours = day["hours"] %}
-            {% set travelTime = day["travel_time"] | timeArrayToString | convert24toHours %}
+            {% set travelTime = (day["travel_time"] | timeArrayToString | convert24toHours) if day["travel_time"] else "-" %}
           {% endif %}
 
           <tr class="govuk-table__row {% if day['attendance_type'] === 'ABSENT' %}mod-highlight-table-row__grey{% endif %}">


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8147)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=772)


### Change description ###
When visiting a {{juror-record/attendance}} page, there will be a table of attendances that the juror has, this has a time-in / out columns and these should always be populated… an attendance will never be confirmed without a time-in / out… it happens that some entries in the database do not have a time-out and this is causing the view to fail on rendering the html. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
