### PR TITLE
hotfix/JM-8169: INC2576126 - Courts unable to confirm attendance for Friday 30th August

### DIFF
--- a/server/routes/juror-management/juror-management.controller.js
+++ b/server/routes/juror-management/juror-management.controller.js
@@ -45,8 +45,8 @@
       const confirmedTab = tab || 'attended';
 
       try {
-        const yesterday = new Date();
-        yesterday.setDate(selectedDate.getDate() - 1);
+        const yesterday = new Date(selectedDate);
+        yesterday.setDate(yesterday.getDate() - 1);
         const previousWorkingDay = setPreviousWorkingDay(new Date(selectedDate));
         const previousWorkingDayIsConfirmed = isAttendanceConfirmedByAttendances(await getAppearances(app, req, req.session.authentication.locCode, dateFilter(previousWorkingDay, null, 'YYYY-MM-DD')));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-8169

### Change description ###

Variable that was used to show previous day link was calculated wrong. It was using the current date as the base, meaning that links for previous months would have the correct day number, but still be using the current month,
Updated to calculate yesterday's date correctly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
