### PR TITLE
task/JM-8144: Review and update expense caching

### DIFF
--- a/server/routes/juror-management/expenses/edit-bank-details/edit-bank-details.controller.js
+++ b/server/routes/juror-management/expenses/edit-bank-details/edit-bank-details.controller.js
@@ -48,10 +48,11 @@
 
       const juror = _.mapKeys(data, (__, key) => _.camelCase(key));
 
-      req.session.bankDetails = {};
-      req.session.bankDetails.etag = headers.etag;
-      req.session.bankDetails.originalDetails = juror;
-
+      req.session[`bankDetails-${jurorNumber}`] = {
+        etag: headers.etag,
+        originalDetails: juror,
+      }
+      
       juror.anonymisedAccountNumber = juror.bankAccountNumber ? '########' : '';
       juror.anonymisedSortCode = juror.sortCode ? '##-##-##' : '';
 
@@ -110,7 +111,7 @@
           app,
           req,
           jurorNumber,
-          req.session.bankDetails.etag
+          req.session[`bankDetails-${jurorNumber}`].etag
         );
 
         req.session.errors = {
@@ -139,11 +140,11 @@
 
       try {
         const accountNumber = req.body.accountNumber === '########'
-          ? req.session.bankDetails.originalDetails.bankAccountNumber
+          ? req.session[`bankDetails-${jurorNumber}`].originalDetails.bankAccountNumber
           : req.body.accountNumber;
 
         const sortCode = req.body.sortCode === '##-##-##'
-          ? req.session.bankDetails.originalDetails.sortCode
+          ? req.session[`bankDetails-${jurorNumber}`].originalDetails.sortCode
           : req.body.sortCode.replace(/-/g, '');
 
         const body = {
@@ -163,7 +164,7 @@
           data: payload,
         });
 
-        delete req.session.bankDetails;
+        delete req.session[`bankDetails-${jurorNumber}`];
 
         return res.redirect(redirectUrl);
       } catch (err) {

--- a/server/routes/juror-management/unpaid-attendance/expense-record/draft.controller.js
+++ b/server/routes/juror-management/unpaid-attendance/expense-record/draft.controller.js
@@ -35,7 +35,7 @@
       getDraftExpensesDAO.get(app, req, jurorNumber, locCode)
         .then(async function({ response: expenseData, headers }) {
 
-          req.session.draftExpensesEtag = headers.etag;
+          req.session[`draftExpensesEtag-${jurorNumber}`] = headers.etag;
 
           app.logger.info('Fetched draft expenses for juror: ', {
             auth: req.session.authentication,
@@ -47,7 +47,7 @@
 
           const totalExpenses = req.expensesCount.total_draft;
 
-          req.session.expensesData = {
+          req.session[`expensesData-${jurorNumber}`] = {
             total: totalExpenses,
             dates: expenseData.expense_details.reduce((prev, expense) => {
               prev.push(expense.attendance_date);
@@ -140,7 +140,7 @@
           req,
           jurorNumber,
           locCode,
-          req.session.draftExpensesEtag
+          req.session[`draftExpensesEtag-${jurorNumber}`]
         );
 
         req.session.errors = {

--- a/server/routes/juror-management/unpaid-attendance/expense-record/expense-record.controller.js
+++ b/server/routes/juror-management/unpaid-attendance/expense-record/expense-record.controller.js
@@ -35,8 +35,8 @@
       }
 
       // always clear the list of edited expenses
-      delete req.session.editedExpenses;
-      delete req.session.editExpenseTravelOverLimit;
+      delete req.session[`editedExpenses-${jurorNumber}`];
+      delete req.session[`editExpenseTravelOverLimit-${jurorNumber}`];
 
       switch (status) {
       case 'draft':

--- a/server/routes/juror-management/unpaid-attendance/expense-record/for-approval.controller.js
+++ b/server/routes/juror-management/unpaid-attendance/expense-record/for-approval.controller.js
@@ -48,10 +48,10 @@
         });
 
         const tmpErrors = _.clone(req.session.errors);
-        const bannerMessage = req.session.submitExpensesBanner;
+        const bannerMessage = req.session[`submitExpensesBanner-${jurorNumber}`];
 
         delete req.session.errors;
-        delete req.session.submitExpensesBanner;
+        delete req.session[`submitExpensesBanner-${jurorNumber}`];
 
         return res.render('juror-management/expense-record/expense-record.njk', {
           backLinkUrl: app.namedRoutes.build('juror-management.unpaid-attendance.get'),
@@ -112,7 +112,7 @@
       }
 
       // always rewrite this
-      req.session.editApprovalDates = (req.body['checked-expenses'] instanceof Array)
+      req.session[`editApprovalDates-${jurorNumber}`] = (req.body['checked-expenses'] instanceof Array)
         ? req.body['checked-expenses']
         : [req.body['checked-expenses']];
 

--- a/server/routes/reporting/audit.controller.js
+++ b/server/routes/reporting/audit.controller.js
@@ -129,41 +129,43 @@ const { getDraftExpensesDAO, getApprovalExpenseListDAO } = require('../../object
   };
 
   const postEditAudit = (app) => async(req, res) => {
-    if (!req.session.editedExpenses) {
+    const { jurorNumber, locCode, status } = req.params;
+    if (!req.session[`editedExpenses-${jurorNumber}`]) {
       req.session.errors = makeManualError('data', 'No expenses have been updated to preview audit report.');
 
       return res.redirect(app.namedRoutes.build(
         'juror-management.edit-expense.get', {
-          jurorNumber: req.params.jurorNumber,
-          locCode: req.params.locCode,
-          status: req.params.status,
+          jurorNumber,
+          locCode,
+          status,
         }));
     }
 
     return res.render('reporting/draft-audit', {
       completeRoute: app.namedRoutes.build(
         'juror-management.edit-expense.get', {
-          jurorNumber: req.params.jurorNumber,
-          locCode: req.params.locCode,
-          status: req.params.status,
+          jurorNumber,
+          locCode,
+          status,
         }
       ),
       printRoute: app.namedRoutes.build('juror-management.edit-expense.preview.get', {
-        jurorNumber: req.params.jurorNumber,
-        locCode: req.params.locCode,
-        status: req.params.status,
+        jurorNumber,
+        locCode,
+        status,
       }),
     });
   };
 
   const getEditAudit = (app) => async(req, res) => {
+    const { jurorNumber, locCode } = req.params
     try {
-      const expenseDates = mapSnakeToCamel(req.session.editApprovalDates);
-      const editedExpenses = mapSnakeToCamel(req.session.editedExpenses);
+      const expenseDates = mapSnakeToCamel(req.session[`editApprovalDates-${jurorNumber}`]);
+      const editedExpenses = mapSnakeToCamel(req.session[`editedExpenses-${jurorNumber}`]);
       const originalExpenses = mapSnakeToCamel(await getApprovalExpenseListDAO.post(
         app, req,
-        req.params.locCode,
-        req.params.jurorNumber,
+        locCode,
+        jurorNumber,
         expenseDates,
       ));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-8066
https://centralgovernmentcgi.atlassian.net/browse/JM-8144

### Change description ###

Removed unused session variables.
Updated session variables throughout expense journeys to be independent for each juror number.
Should allow a user to edit different jurors expenses in multiple tabs at the same time without data issues.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
