### PR TITLE
Hotfix/JS-118: Invalid yield message not showing

### DIFF
--- a/server/config/validation/additional-summons.js
+++ b/server/config/validation/additional-summons.js
@@ -38,8 +38,8 @@
       message.summary = 'Number of citizens to summon is wrong';
       message.details.push('Number of citizens to summon is wrong');
     } else if (+attributes[key] > options.total) {
-      message.summary = 'Number of citizens to summon is too high';
-      message.details.push('Number of citizens to summon is too high');
+      message.summary = 'The number of citizens summoned is too high and exceeds the yield';
+      message.details.push('The number of citizens summoned is too high and exceeds the yield');
     }
 
     // Feedback

--- a/server/objects/axios-instance.js
+++ b/server/objects/axios-instance.js
@@ -51,6 +51,10 @@ client.interceptors.response.use(
         trace: err.response?.data.trace,
       },
     };
+    
+    if (err.response?.data.reasonCode) {
+      error.error.reasonCode = err.response.data.reasonCode
+    }
 
     return Promise.reject(error);
   },

--- a/server/routes/pool-management/additional-summons/additional-summons.controller.js
+++ b/server/routes/pool-management/additional-summons/additional-summons.controller.js
@@ -160,9 +160,9 @@
             error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
           });
 
-          if (err.error.reasonCode && err.error.reasonCode === 'invalid_yield') {
+          if (err.error?.code === 'ERR_BAD_REQUEST' && err.error?.reasonCode === 'invalid_yield') {
             req.session.errors = modUtils
-              .makeManualError('citizensToSummon', 'Number of citizens to summon is too high');
+              .makeManualError('citizensToSummon', 'The number of citizens summoned is too high and exceeds the yield');
           } else if (err.error?.code === 'DATA_IS_OUT_OF_DATE') {
             req.session.errors = modUtils
               .makeManualError('citizensToSummon', err.error.message ?? 'Data is out of date');

--- a/server/routes/pool-management/create-pool/summon-citizens/summon-citizens.controller.js
+++ b/server/routes/pool-management/create-pool/summon-citizens/summon-citizens.controller.js
@@ -124,9 +124,9 @@
             error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
           });
 
-          if (err.error.reasonCode && err.error.reasonCode === 'invalid_yield') {
+          if (err.error?.code === 'ERR_BAD_REQUEST' && err.error?.reasonCode === 'invalid_yield') {
             req.session.errors = modUtils
-              .makeManualError('citizensToSummon', 'Number of citizens to summon is too high');
+              .makeManualError('citizensToSummon', 'The number of citizens summoned is too high and exceeds the yield');
           } else if (err.error?.code === 'DATA_IS_OUT_OF_DATE') {
             req.session.errors = modUtils
               .makeManualError('citizensToSummon', err.error.message ?? 'Data is out of date');


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-118](https://tools.hmcts.net/jira/browse/JS-118)

### Change description ###

Updated axios error handler to pass through error reasonCode if it is present.
Updated invalid yield message to 'The number of citizens summoned is too high and exceeds the yield'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
