### PR TITLE
Feature/JS-148c: Update jurors in waiting 'confirmed' status logic

### DIFF
--- a/client/templates/juror-management/attendance/confirmed/confirmed.njk
+++ b/client/templates/juror-management/attendance/confirmed/confirmed.njk
@@ -87,7 +87,7 @@
                 {{ (row.checkOutTime | timeArrayToString | convert24to12) if row.checkOutTime else "-" }}
               </td>
               <td class="govuk-table__cell" data-sort-value="{{ row.confirmed }}" id="{{ row.jurorNumber }}-confirmed">
-                {{ "Confirmed" if row.appearanceConfirmed or row.appStage === "EXPENSE_ENTERED" or row.appStage === "EXPENSE_AUTHORISED" else  "-" }}
+                {{ "Confirmed" if row.appearanceConfirmed or (row.appStage and row.appStage !== "CHECKED_IN" and row.appStage !== "CHECKED_OUT") else  "-" }}
               </td>
             </tr>
 

--- a/client/templates/juror-management/attendance/unconfirmed/table-row.njk
+++ b/client/templates/juror-management/attendance/unconfirmed/table-row.njk
@@ -52,7 +52,7 @@
     {% endif %}
   </td>
   <td class="govuk-table__cell" data-sort-value="{{ row.confirmed }}" id="{{ row.jurorNumber }}-confirmed">
-    {{ "Confirmed" if row.appearanceConfirmed or row.appStage === "EXPENSE_ENTERED" or row.appStage === "EXPENSE_AUTHORISED" else  "-" }}
+    {{ "Confirmed" if row.appearanceConfirmed or (row.appStage and row.appStage !== "CHECKED_IN" and row.appStage !== "CHECKED_OUT") else  "-" }}
   </td>
   <td class="govuk-table__cell" data-sort-value="{{ row.hasPoliceCheck }}" id="{{ row.jurorNumber }}-police-check">
     {{ policeCheckStatus(row.policeCheck, row.jurorNumber) }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-148](https://tools.hmcts.net/jira/browse/JS-148)

### Change description ###

Updated jurors in waiting 'confirmed' status logic so that it checks for **NOT** CHECKED_IN, CHEKCED_OUT or NULL.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```