### PR TITLE
task/JS-160: Reinstate Middle Option for Returning Jurors

### DIFF
--- a/client/templates/trial-management/returns/return-attendance.njk
+++ b/client/templates/trial-management/returns/return-attendance.njk
@@ -29,7 +29,7 @@
           value: prevAnswer,
           items: [
             { value: 'confirm', text: 'Return and confirm attendance' },
-            { value: 'return', text: 'Return but do not confirm attendance'} if dayIsConfirmed == false,
+            { value: 'return', text: 'Return but do not confirm attendance' },
             { value: 'complete', text: 'Return, confirm attendance and complete their service' }
           ]})
         }}

--- a/server/routes/trial-management/returns.controller.js
+++ b/server/routes/trial-management/returns.controller.js
@@ -9,7 +9,6 @@
   const { convert12to24, dateFilter, convertAmPmToLong } = require('../../components/filters');
   const { padTimeForApi } = require('../../lib/mod-utils');
   const { panelListDAO, trialDetailsObject } = require('../../objects');
-  const isAttendanceConfirmed = require('../juror-management/juror-management.controller').isAttendanceConfirmed;
 
 
   module.exports.postReturnJurors = (app) => async (req, res) => {
@@ -83,23 +82,7 @@
     delete req.session.errors;
     delete req.session[`${trialNumber}-${locationCode}-checkInTime`];
     delete req.session[`${trialNumber}-${locationCode}-checkOutTime`];
-    let dayIsConfirmed;
 
-    try {
-      dayIsConfirmed = await isAttendanceConfirmed(app, req, req.params.locationCode, dateFilter(new Date(), null, 'YYYY-MM-DD'));
-    } catch(err) {
-      app.logger.crit('Failed to check if day is confirmed ', {
-        auth: req.session.authentication,
-        data: {
-          locationCode,
-          trialNumber,
-          attendanceDate: dateFilter(new Date(), null, 'YYYY-MM-DD'),
-        },
-        error: (typeof err.error !== 'undefined') ? err.error : err.toString(),
-      });
-  
-      return res.render('_errors/generic.njk');
-    }
     return res.render('trial-management/returns/return-attendance.njk', {
       formActions: {
         returnUrl: app.namedRoutes.build('trial-management.trials.return.check-out.get', {
@@ -118,7 +101,6 @@
         items: tmpErrors,
       },
       prevAnswer: req.session[`${trialNumber}-${locationCode}-handleAttendance`],
-      dayIsConfirmed: dayIsConfirmed,
     });
   };
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-160](https://tools.hmcts.net/jira/browse/JS-160)

### Change description ###

Reinstate option to 'Return but do not confirm attendance' when returning jurors from a trial.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
