### PR TITLE
hotfix/JS-129: Coroner's pool fails if no voters available

### DIFF
--- a/server/routes/pool-management/coroner-court/coroner-court.controller.js
+++ b/server/routes/pool-management/coroner-court/coroner-court.controller.js
@@ -246,7 +246,8 @@
             , fieldErrorMessages = {}
             , maxExceededError = {};
 
-          if (typeof response !== 'undefined') {
+          if (typeof response !== 'undefined' && response.CourtCatchmentItems) {
+
             postcodes = modUtils.transformPostcodes(response.CourtCatchmentItems)[0];
 
             delete req.session.errors;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-129

### Change description ###

Update so that coroner pool creation does not fail if there are no entries in the voters table.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
