### PR TITLE
Hotfix/JS-265: Technical error on viewing history after SJO confirms attendance

### DIFF
--- a/server/routes/juror-management/juror-record/juror-record.controller.js
+++ b/server/routes/juror-management/juror-record/juror-record.controller.js
@@ -1062,7 +1062,7 @@
         req,
         'overview',
         jurorNumber,
-        req.session.locCode,
+        req.session.locCode || req.session.authentication.locCode,
       );
 
       if (historyTab === 'history') {
@@ -1113,7 +1113,7 @@
         req,
         'detail',
         req.params.jurorNumber,
-        req.session.locCode,
+        req.session.locCode || req.session.authentication.locCode,
       );
 
       const address = [


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-265

### Change description ###

Fixed Api call to fetch juror details on the juror history pages. This was occasionally missing the location code session variable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
