### PR TITLE
task/JS-232: Default summoning progress search to crown court

### DIFF
--- a/client/templates/pool-management/summoning-progress/index.njk
+++ b/client/templates/pool-management/summoning-progress/index.njk
@@ -84,7 +84,7 @@
           {
             value: "CRO",
             text: "Crown court",
-            checked: query.poolType === "CRO"
+            checked: not query.poolType or query.poolType === "CRO"
           },
           {
             value: "CIV",


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-232](https://tools.hmcts.net/jira/browse/JS-232)

### Change description ###

Default to 'Crown Court' radio button when performing summoning progress search

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
