### PR TITLE
JS-298 - add date column to unpaid expenses page

### DIFF
--- a/server/lib/mod-utils.js
+++ b/server/lib/mod-utils.js
@@ -357,6 +357,12 @@
         sortable: true,
       },
       {
+        id: 'lastAttendanceDate',
+        value: 'Last attendance date',
+        sort: sortBy === 'lastAttendanceDate' ? order : 'none',
+        sortable: true,
+      },
+      {
         id: 'viewExpenses',
         value: '',
         sortable: false,
@@ -397,6 +403,12 @@
           text: '£' + parseFloat(unpaid.total_unapproved).toFixed(2),
           attributes: {
             'data-sort-value': unpaid.total_unapproved,
+          },
+        },
+        {
+          text: dateFilter(makeDate(unpaid.last_attendance_date), 'YYYY,MM,DD', 'ddd DD MMM YYYY'),
+          attributes: {
+            'data-sort-value': makeDate(unpaid.last_attendance_date),
           },
         },
         {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/JS-298
https://tools.hmcts.net/jira/browse/JS-339


### Change description ###
Adds a date column on the unpaid expenses report page

NOTE: Dependency on juror-api change
https://tools.hmcts.net/jira/browse/JS-339

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
