### PR TITLE
Task/JS-352: Hide welsh language juror details for non-welsh courts

### DIFF
--- a/client/templates/juror-management/edit/juror-edit-details.njk
+++ b/client/templates/juror-management/edit/juror-edit-details.njk
@@ -500,22 +500,24 @@
               }
             ]
           }) }}
-          {{ govukCheckboxes({
-            name: "welsh",
-            fieldset: {
-              legend: {
-                text: "Tick box if juror should get communications in Welsh (optional)",
-                classes: "govuk-fieldset__legend--m"
-              }
-            },
-            items: [
-              {
-                value: "true",
-                text: "Yes, send Welsh language communications",
-                checked: juror.welsh
-              }
-            ]
-          }) }}
+          {% if juror.commonDetails.is_welsh_court %}
+            {{ govukCheckboxes({
+              name: "welsh",
+              fieldset: {
+                legend: {
+                  text: "Tick box if juror should get communications in Welsh (optional)",
+                  classes: "govuk-fieldset__legend--m"
+                }
+              },
+              items: [
+                {
+                  value: "true",
+                  text: "Yes, send Welsh language communications",
+                  checked: juror.welsh
+                }
+              ]
+            }) }}
+          {% endif %}
         </div>
       </div>
 

--- a/client/templates/juror-management/juror-record/details.njk
+++ b/client/templates/juror-management/juror-record/details.njk
@@ -155,7 +155,7 @@
             value: {
               text: "Yes" if juror.welsh else "No"
             }
-          }
+          } if juror.commonDetails.is_welsh_court
         ]
       }) }}
     </div>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-352](https://tools.hmcts.net/jira/browse/JS-352)

### Change description ###

Hide welsh language juror details selection for non-welsh courts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
