### PR TITLE
hotfix/JS-422: Fix delete letter banner message not displaying

### DIFF
--- a/client/templates/documents/_common/letters-list.njk
+++ b/client/templates/documents/_common/letters-list.njk
@@ -46,7 +46,7 @@
   </div>
 
   {# Delete pending document success #}
-  <div role="region" class="moj-alert moj-alert--success mod-hidden" aria-label="success" data-module="moj-alert">
+  <div id="delete-success" role="region" class="moj-alert moj-alert--success mod-hidden" aria-label="success" data-module="moj-alert">
     <div>
       <svg class="moj-alert__icon" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" height="30" width="30">
         <path d="M11.2869 24.6726L2.00415 15.3899L4.62189 12.7722L11.2869 19.4186L25.3781 5.32739L27.9958 7.96369L11.2869 24.6726Z" fill="currentColor" />


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-422

### Change description ###

Fix delete pending letter success message not showing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
