### PR TITLE
hotfix/JS-450: Fix reassign jurors crash

### DIFF
--- a/server/routes/juror-management/reassign/reassign.controller.js
+++ b/server/routes/juror-management/reassign/reassign.controller.js
@@ -410,11 +410,13 @@
       // TODO: handle better
       // if continuing after validation would leave with no jurors to reassign, redirect without reassigning
       if (jurorNumbers.length <= 0) {
-        let redirectUrl = app.namedRoutes.build('juror-record.overview.get', {jurorNumber: req.params['jurorNumber']});
+        let redirectUrl;
         if (req.session.poolJurorsReassign) {
           redirectUrl = app.namedRoutes.build('pool-overview.get', {poolNumber: req.params['poolNumber']});
         } else if (req.url.includes('details/edit/reassign/select-pool')) {
           redirectUrl = app.namedRoutes.build('juror-record.details.get', {jurorNumber: req.params['jurorNumber']});
+        } else {
+          redirectUrl = app.namedRoutes.build('juror-record.overview.get', {jurorNumber: req.params['jurorNumber']});
         }
 
         return res.redirect(redirectUrl);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-450](https://tools.hmcts.net/jira/browse/JS-450)

### Change description ###

Fixed the following crash causing bug.
Reassign juror from pool overview -> select jurors who don’t meet criteria to be moved (i.e. deferred status) -> shows screen to continue with rest of the available jurors -> if left with 0 jurors allowed to move/reassign -> FE app crashes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
