### PR TITLE
hotfix/JS-708: Disqualify Reason Select List not appearing on summons process screen

### DIFF
--- a/server/routes/summons-management/process-reply/disqualify/process-reply-disqualify.controller.js
+++ b/server/routes/summons-management/process-reply/disqualify/process-reply-disqualify.controller.js
@@ -30,7 +30,7 @@
     delete req.session.formFields;
 
     try {
-      const data = getDisqualificationReasons.get(req);
+      const data = await getDisqualificationReasons.get(req);
 
       app.logger.info('Fetched disqualification reasons: ', {
         auth: req.session.authentication,


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-708](https://tools.hmcts.net/jira/browse/JS-708)

### Change description ###

Added missing 'await' on call to API for summons reply disqaulification.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
