### PR TITLE
hotfix/JS-917: Blacked out  'totals' column in Financial Audit Reports

### DIFF
--- a/client/js/expenses-summary.js
+++ b/client/js/expenses-summary.js
@@ -160,7 +160,7 @@
     data['financialLoss'] = {
       'lossOfEarningsOrBenefits': parseFloatOrZero(lossOfEarnings),
       'extraCareCost': parseFloatOrZero(extraCareCosts),
-      'otherCost': parseFloatOrZero(otherCosts),
+      'otherCosts': parseFloatOrZero(otherCosts),
     };
   }
 

--- a/server/lib/reports/financial-audit.js
+++ b/server/lib/reports/financial-audit.js
@@ -199,7 +199,7 @@
           { 
             text: `${dateFilter(expense.attendanceDate, 'yyyy-MM-dd', 'ddd DD MMM YYYY')}`,
             margin: [0, 5, 0, 0],
-            fillColor: '##F3F3F3'
+            fillColor: '#F3F3F3'
           },
           makeEntry(`${attendanceType(expense.attendanceType)}`,`${attendanceType(expense.original.attendanceType)}`),
           makeEntry(toMoney(expense.lossOfEarnings),toMoney(expense.original.lossOfEarnings)),
@@ -246,7 +246,7 @@
         { text: toMoney(expense.foodAndDrink) },
         { text: toMoney(expense.smartCard) },
         { text: `${expense.paymentMethod}` },
-        { text: toMoney(expense.total), alignment: 'center', fillColor: '##F3F3F3' },
+        { text: toMoney(expense.total), alignment: 'center', fillColor: '#F3F3F3' },
       ]
     });
     
@@ -304,7 +304,7 @@
           { style: 'label', text: 'Food and drink' },
           { style: 'label', text: '(Smart card)' },
           { style: 'label', text: 'Method' },
-          { style: 'label', text: 'Total', alignment: 'center', fillColor: '##F3F3F3' },
+          { style: 'label', text: 'Total', alignment: 'center', fillColor: '#F3F3F3' },
         ],
         body: tableBody,
         widths,

--- a/server/routes/reporting/bespoke-report/bespoke-report-print.js
+++ b/server/routes/reporting/bespoke-report/bespoke-report-print.js
@@ -127,7 +127,7 @@ const bespokeReportTablePrint = {
         }
         poolTrial.push({
           body: [[
-            {text: 'Total unpaid attendances for ' + key + ': ' + counter, style: 'label', fillColor: '#F3F2#F3F3F3F1'},
+            {text: 'Total unpaid attendances for ' + key + ': ' + counter, style: 'label', fillColor: '#F3F3F3'},
           ]],
           widths:['100%'],
           margin: [0, 0, 0, 0],


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-917](https://tools.hmcts.net/jira/browse/JS-917)

### Change description ###

Fixed blacked out  'totals' column in Financial Audit Reports

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
