### PR TITLE
hotfix/JS-924: Fix csv exporting when downloading LA emails

### DIFF
--- a/server/routes/electoral-register/download-emails/download-emails.controller.js
+++ b/server/routes/electoral-register/download-emails/download-emails.controller.js
@@ -32,7 +32,7 @@
 
         res.set('content-disposition', 'attachment; filename=' + filename);
         res.type('csv');
-        res.send(csvResult.join('\n'));
+        res.send(csvResult.map(row => row.map(cell => `"${cell}"`).join(',')).join('\n'));
       }
     } catch (err) {
       app.logger.crit('Error generating local authority email csv', {

--- a/server/routes/electoral-register/download-emails/download-emails.controller.js
+++ b/server/routes/electoral-register/download-emails/download-emails.controller.js
@@ -26,13 +26,13 @@
         csvResult.push(['Local authority', 'Email address']);
         laEmailData.forEach(la => {
           la.emailAddresses.forEach(email => {
-            csvResult.push([la.laName, email.username]);
+            csvResult.push([`"${la.laName}"`, `"${email.username}"`]);
           });
         });
 
         res.set('content-disposition', 'attachment; filename=' + filename);
         res.type('csv');
-        res.send(csvResult.map(row => row.map(cell => `"${cell}"`).join(',')).join('\n'));
+        res.send(csvResult.join('\n'));
       }
     } catch (err) {
       app.logger.crit('Error generating local authority email csv', {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[JS-924](https://tools.hmcts.net/jira/browse/JS-924)

### Change description ###

Fix csv exporting when downloading LA emails with LA names including a comma.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
