### PR TITLE
DTSPO-32018: add Azure Managed Redis instance alongside classic cache

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -80,7 +80,7 @@ module "managed_redis" {
   location    = var.location
   common_tags = var.common_tags
 
-  sku_name = "Balanced_B0"
+  sku_name = var.managed_redis_sku
 
   public_network_access   = "Disabled"
   create_private_endpoint = true
@@ -90,6 +90,7 @@ module "managed_redis" {
   ]
 
   access_keys_authentication_enabled = true
+  persistence_rdb_backup_frequency   = var.managed_redis_persistence_rdb_frequency
 }
 
 resource "azurerm_key_vault_secret" "managed_redis_connection_string" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -59,6 +59,46 @@ resource "azurerm_monitor_diagnostic_setting" "cache-ds" {
   }
 }
 
+# region: Azure Managed Redis (DTSPO-32018)
+# Provisioned alongside the existing classic cache during migration.
+# The classic cache is intentionally NOT removed by this PR — cutover happens
+# via cnp-flux-config, with this resource decommissioned in a follow-up PR
+# once all environments have soaked successfully.
+
+data "azurerm_subnet" "redis_private_endpoint" {
+  name                 = "core-infra-subnet-2-${var.env}"
+  resource_group_name  = "core-infra-${var.env}"
+  virtual_network_name = "core-infra-vnet-${var.env}"
+}
+
+module "managed_redis" {
+  source = "git@github.com:hmcts/terraform-module-azure-managed-redis?ref=main"
+
+  product     = var.product
+  component   = var.component
+  env         = var.env
+  location    = var.location
+  common_tags = var.common_tags
+
+  sku_name = "Balanced_B0"
+
+  public_network_access   = "Disabled"
+  create_private_endpoint = true
+  subnet_id               = data.azurerm_subnet.redis_private_endpoint.id
+  private_dns_zone_ids = [
+    "/subscriptions/${var.private_dns_subscription_id}/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.azure.net"
+  ]
+
+  access_keys_authentication_enabled = true
+}
+
+resource "azurerm_key_vault_secret" "managed_redis_connection_string" {
+  name         = "azure-managed-redis-connection-string"
+  value        = "rediss://default:${urlencode(module.managed_redis.primary_access_key)}@${module.managed_redis.hostname}:${module.managed_redis.port}"
+  key_vault_id = data.azurerm_key_vault.juror.id
+}
+# endregion
+
 module "log_analytics_workspace" {
   source      = "git@github.com:hmcts/terraform-module-log-analytics-workspace-id.git?ref=master"
   environment = var.env

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -2,3 +2,7 @@ sku_name           = "Premium"
 family             = "P"
 capacity           = "1"
 rdb_backup_enabled = true
+
+# Azure Managed Redis (DTSPO-32018) — match existing Premium P1 + RDB
+managed_redis_sku                       = "Balanced_B1"
+managed_redis_persistence_rdb_frequency = "6h"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -55,3 +55,15 @@ variable "private_dns_subscription_id" {
   type        = string
   default     = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 }
+
+variable "managed_redis_sku" {
+  description = "Managed Redis SKU. Default suits non-prod. Override per environment in <env>.tfvars (e.g. prod uses Balanced_B1 to match the existing Premium P1 6GB classic cache)."
+  type        = string
+  default     = "Balanced_B0"
+}
+
+variable "managed_redis_persistence_rdb_frequency" {
+  description = "RDB backup frequency for Managed Redis (1h, 6h, 12h). null = no persistence. Override per environment in <env>.tfvars (prod mirrors the classic cache's rdb_backup_enabled = true with 6h)."
+  type        = string
+  default     = null
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -49,3 +49,9 @@ variable "capacity" {
   default     = "1"
   description = "The size of the Redis cache to deploy. Valid values are 1, 2, 3, 4, 5"
 }
+
+variable "private_dns_subscription_id" {
+  description = "Subscription ID hosting the privatelink.redis.azure.net private DNS zone (core-infra-intsvc-rg). Used by the Azure Managed Redis private endpoint."
+  type        = string
+  default     = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+}


### PR DESCRIPTION
# DTSPO-32018: add Azure Managed Redis instance alongside classic cache

> **Skill demonstration PR — draft only.** Raised by the [`azure-managed-redis-migration`](https://github.com/hmcts/platops-agent-skills/blob/master/.github/skills/azure-managed-redis-migration/SKILL.md) skill to validate the workflow end-to-end. Do not merge without team review.

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32018

### Change description

Adds an Azure Managed Redis instance using [`hmcts/terraform-module-azure-managed-redis`](https://github.com/hmcts/terraform-module-azure-managed-redis), **alongside** the existing classic `cnp-module-redis` cache. The classic cache is intentionally untouched — cutover happens via a follow-up `cnp-flux-config` PR that re-points the application's `redis-connection-string` secret mount onto the new instance.

Pattern is identical to the reference example at [`cnp-plum-recipes-service/infrastructure/main.tf#L136-L178`](https://github.com/hmcts/cnp-plum-recipes-service/blob/master/infrastructure/main.tf#L136-L178).

### What this PR adds

| Resource | Purpose |
|---|---|
| `data.azurerm_subnet.redis_private_endpoint` | `core-infra-subnet-2-<env>` for the new private endpoint |
| `module.managed_redis` | `Balanced_B0`, HA, TLS-only, private endpoint, access-key auth, no persistence |
| `azurerm_key_vault_secret.managed_redis_connection_string` | New KV secret `azure-managed-redis-connection-string` (deliberately distinct from the existing `<component>-redisConnection` so cutover and rollback are clean) |
| `variable.private_dns_subscription_id` | Holds the subscription ID for the `privatelink.redis.azure.net` private DNS zone |

### What this PR does NOT touch

- `module.juror-bureau-redis` (the existing classic cache) — stays in place
- `azurerm_key_vault_secret.redis_connection_string` (existing `<component>-redisConnection` secret) — stays in place
- `azurerm_monitor_diagnostic_setting.cache-ds` on the classic cache — stays in place

### SKU recommendation

Per the [`sku-mapping`](https://github.com/hmcts/platops-agent-skills/blob/master/.github/skills/azure-managed-redis-migration/references/sku-mapping.md) reference:

| Field | Value |
|---|---|
| Current SKU (default) | `Basic C1` (1 GB) |
| Recommended Managed Redis SKU | `Balanced_B0` |
| Rationale | Smallest Balanced tier; HA + TLS the classic Basic tier never had; per-env override possible via tfvars if observed memory/ops warrant a larger SKU |

> **Per-environment tuning:** if any environment runs at higher load (Premium tier today), introduce a per-env `managed_redis_sku` tfvar and consume in the module's `sku_name` argument.

### Migration plan

1. Merge this Terraform PR (per environment via Jenkins as normal).
2. Verify the Managed Redis instance is `provisioningState = Succeeded` and `azure-managed-redis-connection-string` is present in Key Vault `juror-<env>`.
3. Raise a Flux PR against `hmcts/cnp-flux-config` per environment (sbox → dev → ithc → demo → aat → prod) mounting the new secret and aliasing it to the existing app-facing name. See the [skill's flux-example](https://github.com/hmcts/platops-agent-skills/blob/master/.github/skills/azure-managed-redis-migration/references/flux-example.md).
4. Soak each environment before promoting to the next.
5. **Decommission PR (separate, much later):** once prod has been stable for the agreed soak window, raise a follow-up PR that removes `module.juror-bureau-redis`, the classic cache diagnostic setting, and the old `<component>-redisConnection` Key Vault secret.

### Data migration

Juror Bureau Redis usage to be confirmed with the team. Default assumption: **session/cache only** — Approach A (no migration) per [the skill](https://github.com/hmcts/platops-agent-skills/blob/master/.github/skills/azure-managed-redis-migration/references/data-migration.md). If the cache holds anything that must survive cutover, switch to Approach B (dual-write) or C (RDB export/import) before merging the Flux PR.

### Testing done

- `terraform fmt -check` ✅
- Diff reviewed locally; additive only (46 lines), classic resources untouched
- Module reference (`?ref=main`) matches the canonical HMCTS pattern

> Full `terraform plan` will run in Jenkins per environment; review the plan output before merging.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed) — n/a
- [ ] tests have been updated / new tests has been added (if needed) — n/a, infrastructure-only
- [ ] Does this PR introduce a breaking change — no, additive only; classic cache remains
