### PR TITLE
Task/JS-974: Unable to send a message to a juror where phone number is >15 digits

### DIFF
--- a/server/config/validation/paper-reply.js
+++ b/server/config/validation/paper-reply.js
@@ -13,6 +13,7 @@
     emailAddress: 'Enter a valid email address',
     thirdPartyEmailAddress: 'Enter a valid third party email address',
   };
+  const { stripPrefixes } = require('../../lib/mod-utils');
 
   require('./common-email-address');
   require('./date-picker');
@@ -545,27 +546,6 @@
     }
 
     return null;
-  };
-
-  function stripPrefixes(phoneNumber) {
-    let strippedPhoneNumber = phoneNumber;
-
-    if (strippedPhoneNumber.slice(0, 2) === '44') {
-      strippedPhoneNumber = strippedPhoneNumber.slice(2);
-    } else if (strippedPhoneNumber.slice(0, 3) === '+44') {
-      strippedPhoneNumber = strippedPhoneNumber.slice(3);
-    } else if (strippedPhoneNumber.slice(0, 4) === '0044') {
-      strippedPhoneNumber = strippedPhoneNumber.slice(4);
-    }
-
-    strippedPhoneNumber = strippedPhoneNumber.replace(/\s/g, '').replace(/[()-]/g, '');
-
-    if (strippedPhoneNumber.slice(0, 1) !== '0') {
-      strippedPhoneNumber = '0' + strippedPhoneNumber;
-    }
-
-    return strippedPhoneNumber;
-
   };
 
   validate.validators.nameFieldValidator = function(value, options, key, attributes) {

--- a/server/lib/mod-utils.js
+++ b/server/lib/mod-utils.js
@@ -1549,4 +1549,34 @@
     return months;
   };
 
+  const stripPrefixes = (phoneNumber) => {
+    let strippedPhoneNumber = phoneNumber;
+
+    if (strippedPhoneNumber.slice(0, 2) === '44') {
+      strippedPhoneNumber = strippedPhoneNumber.slice(2);
+    } else if (strippedPhoneNumber.slice(0, 3) === '+44') {
+      strippedPhoneNumber = strippedPhoneNumber.slice(3);
+    } else if (strippedPhoneNumber.slice(0, 4) === '0044') {
+      strippedPhoneNumber = strippedPhoneNumber.slice(4);
+    }
+
+    strippedPhoneNumber = strippedPhoneNumber.replace(/\s/g, '').replace(/[()-]/g, '');
+
+    if (strippedPhoneNumber.slice(0, 1) !== '0') {
+      strippedPhoneNumber = '0' + strippedPhoneNumber;
+    }
+
+    return strippedPhoneNumber;
+  };
+
+  module.exports.stripPrefixes = stripPrefixes;
+
+  module.exports.stripSpacesFromPhoneNumbersInBody = (req) => {
+    Object.keys(req.body).forEach((key) => {
+      if (key.toLowerCase().includes('phone') && typeof req.body[key] === 'string' && req.body[key] !== '' && req.body[key] !== null) {
+        req.body[key] = stripPrefixes(req.body[key]);
+      }
+    });
+  }
+
 })();

--- a/server/routes/juror-management/edit/juror-edit.controller.js
+++ b/server/routes/juror-management/edit/juror-edit.controller.js
@@ -587,6 +587,8 @@
       const { jurorNumber } = req.params;
       let validatorResult = validate(req.body, overviewDetailsValidator());
 
+      modUtils.stripSpacesFromPhoneNumbersInBody(req);
+
       if (!req.session[`editJurorDetails-${jurorNumber}`]) {
         return res.render('_errors/generic', { err });
       }

--- a/server/routes/summons-management/paper-reply/paper-reply.controller.js
+++ b/server/routes/summons-management/paper-reply/paper-reply.controller.js
@@ -154,6 +154,8 @@
 
     const detailsValidatorResult = validate(req.body, paperReplyValidator.jurorDetails());
 
+    modUtils.stripSpacesFromPhoneNumbersInBody(req);
+
     req.session.startedPaperResponse = true;
 
     // build thirdParty Object if any detail in the relationship field


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-974

### Change description ###

Phone numbers were not being stripped of spaces or dashes before being sent to API to be saved on DB.
This meant phone numbers could be longer than 15 characters, causing the send messages module to fall over when selecting that juror.
Updated paper reply and edit juror flows to use same stripping of phone numbers in the phone number validation.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
